### PR TITLE
rm identifier.type binding

### DIFF
--- a/input/fsh/profiles/FRCoreScheduleProfile.fsh
+++ b/input/fsh/profiles/FRCoreScheduleProfile.fsh
@@ -19,8 +19,6 @@ This profile redefines the element serviceType to associate the service with the
     FRCoreServiceTypeDurationExtension named serviceTypeDuration 0..* and
     FRCoreScheduleAvailabilityTimeExtension named availabilityTime 0..*
 
-* identifier.use from IdentifierUse (required)
-
 * serviceCategory ..1
 * serviceType ..0
 * specialty from FRCoreValueSetPractitionerSpecialty (required)


### PR DESCRIPTION
Suppression du binding identifier.use (inutile, déjà présent par défaut).
identifier.type : binding hérité de FHIR Core (possiblement un JDV à créer ?)

@isa-ans, est-ce que le problème est réglé ?