### PR TITLE
Patient.gender INS contiennent uniquement male female unknown

### DIFF
--- a/input/fsh/profiles/FrCorePatientINS.fsh
+++ b/input/fsh/profiles/FrCorePatientINS.fsh
@@ -37,6 +37,8 @@ Description: """Profil FrPatient appliqué à l'INS."""
 // Identifier : soit INS-NIR, soit INS-NIA obligatoire
 
 * gender 1..1
+* gender from fr-core-patient-gender-INS (required)
+* gender ^short = "male | female | unknown"
 
 * birthDate 1..
 

--- a/input/fsh/valuesets/FRCoreValueSetPatientGenderINS.fsh
+++ b/input/fsh/valuesets/FRCoreValueSetPatientGenderINS.fsh
@@ -1,7 +1,7 @@
 ValueSet: FRCoreValueSetPatientGenderINS
 Id: fr-core-patient-gender-INS
 Title: "FR Core ValueSet Patient gender INS ValueSet"
-Description: "Patient Gender for INS : male | female | other"
+Description: "Patient Gender for INS : male | female | unknown"
 * include http://hl7.org/fhir/administrative-gender#male
 * include http://hl7.org/fhir/administrative-gender#female
 * include http://hl7.org/fhir/administrative-gender#unknown

--- a/input/fsh/valuesets/FRCoreValueSetPatientGenderINS.fsh
+++ b/input/fsh/valuesets/FRCoreValueSetPatientGenderINS.fsh
@@ -1,0 +1,7 @@
+ValueSet: FRCoreValueSetPatientGenderINS
+Id: fr-core-patient-gender-INS
+Title: "FR Core ValueSet Patient gender INS ValueSet"
+Description: "Patient Gender for INS : male | female | other"
+* include http://hl7.org/fhir/administrative-gender#male
+* include http://hl7.org/fhir/administrative-gender#female
+* include http://hl7.org/fhir/administrative-gender#unknown


### PR DESCRIPTION
Dans RNIV:
- Il y a male / female / unknown (à vérifier)
<img width="716" alt="image" src="https://github.com/Interop-Sante/hl7.fhir.fr.core/assets/48218773/64611d4e-e968-45cc-94ac-6c488a9821a8">

[RNIV (page 33)](https://esante.gouv.fr/sites/default/files/media_entity/documents/RNIV%201%20Principes%20communs_1.pdf
)

Dans PAM:
- il y a male / female / other / unknown

Proposition : enlever other dans PAM