### PR TITLE
Add French jurisdiction

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -16,6 +16,7 @@ version: 2.0.0
 fhirVersion: 4.0.1
 copyrightYear: 2023+
 releaseLabel: ci-build
+jurisdiction: urn:iso:std:iso:3166#FR "France"
 
 parameters:
     shownav: 'true'


### PR DESCRIPTION
## Description des changements

Added French jurisdiction to the IG, halving the number of errors.

Before:
errors = 112, warn = 244, info = 2, broken links = 0

After:
errors = 45, warn = 189, info = 2, broken links = 0

## Preview
(it's a fork so no preview)
