### PR TITLE
add birth list given name extension to patient profile

### DIFF
--- a/input/fsh/profiles/FRCorePatientProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientProfile.fsh
@@ -89,6 +89,9 @@ This profile specifies the patient's identifiers for France. It uses internation
 * name[officialName].use = #official
 * name[officialName].family 1..
 * name[officialName].given 1..1
+
+* name[officialName].extension contains fr-core-patient-birth-list-given-name named birth-list-given-name 0..1
+
 // TODO : rajouter l'extenion text
 
 

--- a/input/fsh/profiles/FrCorePatientINS.fsh
+++ b/input/fsh/profiles/FrCorePatientINS.fsh
@@ -47,7 +47,7 @@ Description: """Profil FrPatient appliqué à l'INS avec identité validée. Pou
 * name[officialName].given 1..1
 * name[officialName].given ^short = "Dans le cas d’une identité créée ou modifiée par un appel au téléservice INSi, il est nécessaire d’extraire le premier prénom de la liste des prénoms retournée par le téléservice et de l'inclure dans le champs given. En cas de prénom composé, given peut par exemple contenir 'Anne-sophie' ou 'Anne Sophie'."
 
-* name[officialName].extension contains fr-core-patient-birth-list-given-name named birth-list-given-name 1..1
+* name[officialName].extension[birth-list-given-name] 1..1
 
 
 Invariant:   fr-core-1


### PR DESCRIPTION
## Description des changements | Description of changes made

* Ajout de la liste des prénoms sur la ressource Patient au lieu de la ressource PatientINS

## Preview

https://interop-sante.github.io/FHIR-FR-Core/ig/[ajouter_nom_de_la_branche] 
