### PR TITLE
MAJ NIR - DESCR NIR FrCorePatientINS.fsh + Ajout NSS au FrCorePatient

### DIFF
--- a/input/fsh/profiles/FRCorePatientProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientProfile.fsh
@@ -33,12 +33,20 @@ This profile specifies the patient's identifiers for France. It uses internation
 * identifier ^slicing.rules = #open
 * identifier ^short = "An identifier for this patient | Identifiant patient. Pour modéliser un patient avec une INS validée, il est nécessaire de respecter la conformité au profil FrCorePatientINS. Les identifiants NIR et NIA ne sont définis uniquement dans le cas du FRCorePatientINS."
 * identifier contains
+    NSS 0..1 and
     INS-C 0..* and
     NDP 0..1 and
     PI 0..1 and
     RRI 0..*
 
-* identifier[INS-C] ^definition = "Computed National Health Identifier | Identifiant National de Santé Calculé à partir des éléments de la carte vitale"
+
+* identifier[NSS] ^short = "National Health Plan Identifier | Le Numéro d'Inscription au Répertoire (NIR) de facturation permet de faire transiter le numéro de sécurité social de l’ayant droit ou du bénéfiaire (patient) / le numéro de sécurité sociale de l’ouvrant droit (assuré)."
+* identifier[NSS].use = #official
+* identifier[NSS].type = http://terminology.hl7.org/CodeSystem/v2-0203#NH
+* identifier[NSS].system = "urn:oid:1.2.250.1.213.1.4.8"
+* identifier[NSS].value 1..
+
+* identifier[INS-C] ^short = "Computed National Health Identifier | Identifiant National de Santé Calculé à partir des éléments de la carte vitale"
 * identifier[INS-C].use = #secondary
 * identifier[INS-C].type = $fr-core-v2-0203#INS-C "Identifiant National de Santé Calculé"
 * identifier[INS-C].type ^definition = "Computed National Health Identifier | Identifiant National de Santé Calculé à partir des éléments de la carte vitale"
@@ -48,21 +56,17 @@ This profile specifies the patient's identifiers for France. It uses internation
 * identifier[NDP] ^short = "French pharmaceutical Record Identifier | Numéro de Dossier Pharmaceutique français. Celui-ci est unique."
 * identifier[NDP].use = #secondary
 * identifier[NDP].type = $fr-core-v2-0203#NDP "Identifiant du patient au Dossier Pharmaceutique"
-* identifier[NDP].type ^binding.extension[+].url = "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding"
-* identifier[NDP].type ^binding.extension[=].valueBoolean = true
 * identifier[NDP].system 1..
 * identifier[NDP].system = "urn:oid:1.2.250.1.176.1.2"
 * identifier[NDP].value 1..
 
 * identifier[PI] ^short = "Hospital assigned patient identifier | IPP"
-* identifier[PI] ^definition = "Hospital assigned patient identifier | IPP"
 * identifier[PI].use = #usual
 * identifier[PI].type = http://terminology.hl7.org/CodeSystem/v2-0203#PI "Patient internal identifier"
 * identifier[PI].system 1..
 * identifier[PI].value 1..
 
 * identifier[RRI] ^short = "Regional Registry ID | Identifiant régional"
-* identifier[RRI] ^definition = "Regional Registry ID | Identifiant régional"
 * identifier[RRI].use = #secondary
 * identifier[RRI].type = http://terminology.hl7.org/CodeSystem/v2-0203#RRI "Regional registry ID"
 * identifier[RRI].system 1..

--- a/input/fsh/profiles/FrCorePatientINS.fsh
+++ b/input/fsh/profiles/FrCorePatientINS.fsh
@@ -22,8 +22,7 @@ Description: """Profil FRCorePatientProfile appliqué à l'INS avec identité va
 
 // Slices définies dans PatientINS car ne peuvent pas être véhiculé si identité non qualifiée.
 
-* identifier[INS-NIR] ^short = "The patient's health national identifier INS coming from the INSi teleservice| Identifiant national de santé du patient INS provenant du téléservice INSi"
-* identifier[INS-NIR] ^definition = "patient's national identifier obtained by requesting the national patient identification service (CNAM) | Identifiant NIR du patient récupéré à partir de l'interrogation du service national d'identification des patients (CNAM)"
+* identifier[INS-NIR] ^short = "The patient's health national identifier INS coming from the INSi teleservice| Numéro d'Inscription au Répertoire (NIR) ou numéro de sécurité sociale du patient INS provenant du téléservice INSi."
 * identifier[INS-NIR].use = #official
 * identifier[INS-NIR].type = $fr-core-v2-0203#INS-NIR
 * identifier[INS-NIR].system = "urn:oid:1.2.250.1.213.1.4.8"

--- a/input/fsh/profiles/FrCorePatientINS.fsh
+++ b/input/fsh/profiles/FrCorePatientINS.fsh
@@ -22,15 +22,14 @@ Description: """Profil FRCorePatientProfile appliqué à l'INS avec identité va
 
 // Slices définies dans PatientINS car ne peuvent pas être véhiculé si identité non qualifiée.
 
-* identifier[INS-NIR] ^short = "The patient's health national identifier INS coming from the INSi teleservice| Numéro d'Inscription au Répertoire (NIR) ou numéro de sécurité sociale du patient INS provenant du téléservice INSi."
+* identifier[INS-NIR] ^short = "INS-NIR - The patient health national identifier INS coming from the INSi teleservice | Numéro d'Inscription au Répertoire (NIR) du patient INS provenant du téléservice INSi de la CNAM."
 * identifier[INS-NIR].use = #official
 * identifier[INS-NIR].type = $fr-core-v2-0203#INS-NIR
 * identifier[INS-NIR].system = "urn:oid:1.2.250.1.213.1.4.8"
 * identifier[INS-NIR].system ^short = "Autorité d'affectation des INS-NIR"
 * identifier[INS-NIR].value 1..
 
-* identifier[INS-NIA] ^short = "INS-NIA"
-* identifier[INS-NIA] ^definition = "The temporary patient's health national identifier obtained by requesting the national patient identification service (CNAM)| Identifiant national temporaire de santé du patient obtenu par interrogation du téléservice INSi de la CNAM"
+* identifier[INS-NIA] ^short = "INS-NIA - The temporary patient health national identifier obtained by requesting the national patient identification service (CNAM)| Identifiant national temporaire de santé du patient obtenu par interrogation du téléservice INSi de la CNAM."
 * identifier[INS-NIA].use = #temp
 * identifier[INS-NIA].type = $fr-core-v2-0203#INS-NIA
 * identifier[INS-NIA].system = "urn:oid:1.2.250.1.213.1.4.9"

--- a/input/fsh/valuesets/FRCoreValueSetIdentifierType.fsh
+++ b/input/fsh/valuesets/FRCoreValueSetIdentifierType.fsh
@@ -14,6 +14,7 @@ Description: "A coded type for an identifier that can be used to determine which
 * $fr-core-v2-0203#INS-C "Identifiant National de Santé Calculé"
 * $fr-core-v2-0203#INS-NIA "NIR temporaire"
 * $fr-core-v2-0203#INS-NIR "NIR définitif"
+* http://terminology.hl7.org/CodeSystem/v2-0203#NH "Numéro de sécurité sociale"
 
 // SVS profile
 * ^experimental = false


### PR DESCRIPTION
Le Numéro d'Inscription au Répertoire (NIR), également appelé numéro de sécurité sociale, ne semble pas être propre au patient INS. En effet, on peut vouloir indiquer le numéro de sécurité sociale d'un patient qui n'a pas une INS qualifiée.

Ainsi, on peut distinguer deux sortes d'identifiants : 
- les INS-NIR et INS-NIA, qui sont validés par le téléservice INSi
- Le NIR (numéro de sécurité sociale) qui a été obtenu depuis la Carte Vitale par exemple.

## Proposition 1  : laisser la slice INS-NIR + rajouter une extension NIR dans le profil FrCorePatient
extension NIR :
- Type Identifier 
- Extension car le NIR n'identifie pas de manière unique un patient, un enfant et sa mère pouvant avoir le même NIR.
- Rendre cette extension interdite dans le cadre du patient INS qualifié


## Proposition 2  : ne pas ajouter le numéro de SS dans FrPatient
Expliquer pourquoi si quelque chose le justifie

## Description des changements | Description of changes made

* Mise à jour de la description de la slice INS-NIR

## Preview

https://interop-sante.github.io/FHIR-FR-Core/ig/nr-update-nir


PR associées : https://github.com/Interop-Sante/hl7.fhir.fr.core/pull/115 https://github.com/Interop-Sante/hl7.fhir.fr.core/pull/64