### PR TITLE
Mise à jour des spécialités

### DIFF
--- a/input/fsh/profiles/FRCoreHealthcareServiceProfile.fsh
+++ b/input/fsh/profiles/FRCoreHealthcareServiceProfile.fsh
@@ -22,7 +22,10 @@ This profile adds the element serviceTypeDuration to associate the service with 
 
 * providedBy only Reference(FRCoreOrganizationProfile)
 * category ..1
-* specialty from FRCoreValueSetPractitionerSpecialty (required)
+
+* specialty from FRCoreValueSetPractitionerSpecialty (preferred)
+// TODO - Une étude approfondie doit être faite sur les spécialités médicales : R38, R211, R266, R01 ...
+
 * location only Reference(FRCoreLocationProfile)
 * telecom only FRCoreContactPointProfile
 * coverageArea only Reference(FRCoreLocationProfile)

--- a/input/fsh/profiles/FRCoreHealthcareServiceProfile.fsh
+++ b/input/fsh/profiles/FRCoreHealthcareServiceProfile.fsh
@@ -25,6 +25,7 @@ This profile adds the element serviceTypeDuration to associate the service with 
 
 * specialty from FRCoreValueSetPractitionerSpecialty (preferred)
 // TODO - Une étude approfondie doit être faite sur les spécialités médicales : R38, R211, R266, R01 ...
+// La TRE à privilégier semble être la TRE R211 utilisée par le ROR
 
 * location only Reference(FRCoreLocationProfile)
 * telecom only FRCoreContactPointProfile

--- a/input/fsh/profiles/FRCoreHealthcareServiceProfile.fsh
+++ b/input/fsh/profiles/FRCoreHealthcareServiceProfile.fsh
@@ -30,4 +30,3 @@ This profile adds the element serviceTypeDuration to associate the service with 
 * location only Reference(FRCoreLocationProfile)
 * telecom only FRCoreContactPointProfile
 * coverageArea only Reference(FRCoreLocationProfile)
-* availableTime.daysOfWeek from DaysOfWeek (required)

--- a/input/fsh/profiles/FRCorePractitionerProfile.fsh
+++ b/input/fsh/profiles/FRCorePractitionerProfile.fsh
@@ -20,8 +20,7 @@ This profile specifies the types of identifiers for practitioners in France | Ce
 
 * extension contains
     fr-core-practitioner-specialty named specialty 0..1
-
-
+    
 
 * identifier.type from FRCoreValueSetPractitionerIdentifierType (extensible)
 * identifier.type.coding.system ^example[0].label = "CodeSystem HL7v2 (PAM) pour un type d'identifiant PS"

--- a/input/fsh/profiles/FRCorePractitionerProfile.fsh
+++ b/input/fsh/profiles/FRCorePractitionerProfile.fsh
@@ -14,6 +14,15 @@ This profile specifies the types of identifiers for practitioners in France | Ce
 * meta.profile contains fr-canonical 0..1
 * meta.profile[fr-canonical] = Canonical(fr-core-practitioner)
 
+* extension ^slicing.discriminator.type = #value
+* extension ^slicing.discriminator.path = "url"
+* extension ^slicing.rules = #open
+
+* extension contains
+    fr-core-practitioner-specialty named specialty 0..1
+
+
+
 * identifier.type from FRCoreValueSetPractitionerIdentifierType (extensible)
 * identifier.type.coding.system ^example[0].label = "CodeSystem HL7v2 (PAM) pour un type d'identifiant PS"
 * identifier.type.coding.system ^example[=].valueUri = "http://terminology.hl7.org/CodeSystem/v2-0203"

--- a/input/fsh/profiles/FRCorePractitionerRoleProfession.fsh
+++ b/input/fsh/profiles/FRCorePractitionerRoleProfession.fsh
@@ -16,6 +16,7 @@ Description: "Profile of the PractitionerRole resource. This profile specifies t
 
 * practitioner only Reference(FRCorePractitionerProfile)
 * organization only Reference(FRCoreOrganizationProfile)
+
 * code from $fr-practitioner-role-profession (required)
 * code ^short = "Professions which this practitioner may have"
 * code ^definition = "Professions which this practitioner is authorized to perform in France. | Professions que le PS est autorisé à réaliser"
@@ -23,6 +24,7 @@ Description: "Profile of the PractitionerRole resource. This profile specifies t
 * code.extension ^slicing.discriminator.path = "url"
 * code.extension ^slicing.rules = #open
 * code.extension contains FrCorePractitionerRoleCodeCategorieProfessionnelle named professionnalCategory 0..1
+
 * specialty from $fr-practitioner-specialty (required)
 * location ..0
 * healthcareService ..0

--- a/input/fsh/profiles/FRCorePractitionerRoleProfession.fsh
+++ b/input/fsh/profiles/FRCorePractitionerRoleProfession.fsh
@@ -24,7 +24,7 @@ Description: "Profile of the PractitionerRole resource. This profile specifies t
 * code.extension ^slicing.discriminator.type = #value
 * code.extension ^slicing.discriminator.path = "url"
 * code.extension ^slicing.rules = #open
-* code.extension contains FrCorePractitionerRoleCodeCategorieProfessionnelle named professionnalCategory 0..1
+* code.extension contains FRCorePractitionerRoleCodeCategorieProfessionnelle named professionnalCategory 0..1
 
 * specialty from $fr-practitioner-specialty (required)
 

--- a/input/fsh/profiles/FrCorePractitionerRoleExercice.fsh
+++ b/input/fsh/profiles/FrCorePractitionerRoleExercice.fsh
@@ -27,9 +27,10 @@ Description: "Profil of the PractitionerRole resource for France. This profil sp
 * code ^short = "The role a person plays representing an organization | Rôle (situation d'exercice) du professionnel de santé au sein de l'organisation"
 * code ^definition = "The role a person plays representing an organization | Situation d'exercice (Fonction dans le NOS)"
 * code ^binding.description = "The role a person plays representing an organization | Rôle (situation d'exercice) du professionnel de santé au sein de l'organisation. Correspond à la notion de Fonction dans le NOS."
+
 * specialty from $fr-practitioner-specialty (required)
 * specialty ^short = "Specific specialty associated with the agency | spécialité du professionnel de santé au sein de l'organisation"
-* specialty ^definition = "Specific specialty associated with the agency | spécialité du professionnel de santé au sein de l'organisation."
+
 * location only Reference(FRCoreLocationProfile)
 * healthcareService only Reference(FRCoreHealthcareServiceProfile)
 * telecom only FRCoreContactPointProfile


### PR DESCRIPTION
## Description des changements | Description of changes made

* La contrainte HealthcareService.specialty a été relâchée
* L'usage de l'extension practitioner-specialty a été défini dans le profil FrPractitioner.

## TODO

Une étude supplémentaire devra être réalisée au niveau des référentiels de l'ANS pour éclaircir l'usage des spécialités (TRE identifiées : R38, R211, R266, R01 ...) 

## Preview

https://interop-sante.github.io/hl7.fhir.fr.core/ig/nr-update-specialty