### PR TITLE
main en ci-build

### DIFF
--- a/publication-request.json
+++ b/publication-request.json
@@ -1,13 +1,13 @@
 {
     "package-id" : "hl7.fhir.fr.core",
-    "version" : "2.0.0",
-    "path" : "https://hl7.fr/ig/fhir/core/2.0.0",
-    "mode" : "milestone",
-    "status" : "release",
+    "version" : "2.0.1",
+    "path" : "https://hl7.fr/ig/fhir/core/2.0.1",
+    "mode" : "working",
+    "status" : "informative",
     "sequence" : "trial-use",
     "title" : "Guide d'implémentation Fr Core",
     "desc" : "Guide d'implémentation Fr Core 2.0.0 - profils génériques à usage national",
-    "descmd" : "Release 2.0.0 de l'Implementation Guide FrCore.\n- Migration de l'ensemble des profils depuis simplifier vers le guide d'implémentation au format FSH.\n- Changement et uniformisation des noms, titres, descriptions id et url des ressources de conformité.\n- Suppression des contraintes trop fortes (ex. cardinalités minimales à 1, binding de terminologies trop fort) pour faciliter l'utilisation des profils FrCore\n- Rajout du profil FrPatientINS pour identifier les 5 traits obligatoires.\n- Ajout d'exemples\n- Mise à jour des slices d'identifier des patients (NIR, NIA, ...), Practiciens (RPPS, IDNATPS, ...), Organisation (FINESS, IDNATST, ...)",
+    "descmd" : "Release 2.0.1 de l'Implementation Guide FrCore.\n- ci-build",
     "ci-build" : "https://interop-sante.github.io/hl7.fhir.fr.core/main/ig",
     "category" : "National Base",
     "introduction" : "Guide d'implémentation Fr Core."

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -12,10 +12,10 @@ contact:
         value: fhir@interopsante.org
         use: work
 status: active
-version: 2.0.0
+version: 2.0.1
 fhirVersion: 4.0.1
 copyrightYear: 2023+
-releaseLabel: trial-use
+releaseLabel: ci-build
 jurisdiction: urn:iso:std:iso:3166#FR "France"
 
 dependencies:


### PR DESCRIPTION
## Description des changements | Description of changes made

changement pour passer le main en ci-build afin de distinguer la ci-build de la version publiée 2.0.0


## Preview

https://interop-sante.github.io/hl7.fhir.fr.core/sd-ci-build/ig

