### PR TITLE
Update practitioner qualification discriminator

### DIFF
--- a/input/fsh/profiles/FRCorePractitionerProfile.fsh
+++ b/input/fsh/profiles/FRCorePractitionerProfile.fsh
@@ -71,7 +71,7 @@ Description: """Profil de la ressource Practitionner pour la France."""
 // # DIPLOME #
 // ###########
 
-* qualification ^slicing.discriminator.type = #value
+* qualification ^slicing.discriminator.type = #pattern
 * qualification ^slicing.discriminator.path = "$this"
 * qualification ^slicing.rules = #open
 * qualification contains degree 0..*
@@ -80,7 +80,7 @@ Description: """Profil de la ressource Practitionner pour la France."""
 * qualification[degree] ^short = "Diplôme et type de diplôme, par exemple : DE, DES, CES, etc. (typeDiplome)"
 
 * qualification[degree].code.coding ^slicing.discriminator.type = #value
-* qualification[degree].code.coding ^slicing.discriminator.path = "system"
+* qualification[degree].code.coding ^slicing.discriminator.path = "$this"
 * qualification[degree].code.coding ^slicing.rules = #closed
 
 * qualification[degree].code.coding contains degreeType 0..1 and degree 0..1 
@@ -101,7 +101,7 @@ Description: """Profil de la ressource Practitionner pour la France."""
 
 * qualification[exercicePro] ^short = "exercicePro : exercice professionnel décrivant la profession exercée, l'identité d'exercice d'un professionnel et le cadre de son exercice (civil, militaire, etc.)." 
 * qualification[exercicePro].code.coding ^slicing.discriminator.type = #value
-* qualification[exercicePro].code.coding ^slicing.discriminator.path = "system"
+* qualification[exercicePro].code.coding ^slicing.discriminator.path = "$this"
 * qualification[exercicePro].code.coding ^slicing.rules = #closed
 
 * qualification[exercicePro].code.coding contains 
@@ -127,7 +127,7 @@ Description: """Profil de la ressource Practitionner pour la France."""
 * qualification[savoirFaire] ^short = "savoirFaire : Prérogatives d'exercice d'un professionnel reconnues par une autorité d'enregistrement sur une période donnée de son exercice professionnel, par exemple les spécialités ordinales, etc."
 
 * qualification[savoirFaire].code.coding ^slicing.discriminator.type = #value
-* qualification[savoirFaire].code.coding ^slicing.discriminator.path = "system"
+* qualification[savoirFaire].code.coding ^slicing.discriminator.path = "$this"
 * qualification[savoirFaire].code.coding ^slicing.rules = #open
 
 * qualification[savoirFaire].code.coding contains

--- a/input/fsh/profiles/FRCorePractitionerProfile.fsh
+++ b/input/fsh/profiles/FRCorePractitionerProfile.fsh
@@ -124,7 +124,7 @@ Description: """Profil de la ressource Practitionner pour la France."""
 * qualification contains savoirFaire 0..*
 
 
-* qualification[savoirFaire] ^short = "savoirFAire : Prérogatives d'exercice d'un professionnel reconnues par une autorité d'enregistrement sur une période donnée de son exercice professionnel, par exemple les spécialités ordinales, etc."
+* qualification[savoirFaire] ^short = "savoirFaire : Prérogatives d'exercice d'un professionnel reconnues par une autorité d'enregistrement sur une période donnée de son exercice professionnel, par exemple les spécialités ordinales, etc."
 
 * qualification[savoirFaire].code.coding ^slicing.discriminator.type = #value
 * qualification[savoirFaire].code.coding ^slicing.discriminator.path = "system"

--- a/input/fsh/profiles/FRCorePractitionerProfile.fsh
+++ b/input/fsh/profiles/FRCorePractitionerProfile.fsh
@@ -101,7 +101,7 @@ Description: """Profil de la ressource Practitionner pour la France."""
 
 * qualification[exercicePro] ^short = "exercicePro : exercice professionnel décrivant la profession exercée, l'identité d'exercice d'un professionnel et le cadre de son exercice (civil, militaire, etc.)." 
 * qualification[exercicePro].code.coding ^slicing.discriminator.type = #value
-* qualification[exercicePro].code.coding ^slicing.discriminator.path = "$this"
+* qualification[exercicePro].code.coding ^slicing.discriminator.path = "code.coding"
 * qualification[exercicePro].code.coding ^slicing.rules = #closed
 
 * qualification[exercicePro].code.coding contains 
@@ -128,7 +128,7 @@ Description: """Profil de la ressource Practitionner pour la France."""
 
 * qualification[savoirFaire].code.coding ^slicing.discriminator.type = #value
 * qualification[savoirFaire].code.coding ^slicing.discriminator.path = "$this"
-* qualification[savoirFaire].code.coding ^slicing.rules = #open
+* qualification[savoirFaire].code.coding ^slicing.rules = #closed
 
 * qualification[savoirFaire].code.coding contains
     typeSavoirFaire 0..1 and

--- a/input/fsh/profiles/FRCorePractitionerProfile.fsh
+++ b/input/fsh/profiles/FRCorePractitionerProfile.fsh
@@ -72,7 +72,7 @@ Description: """Profil de la ressource Practitionner pour la France."""
 // ###########
 
 * qualification ^slicing.discriminator.type = #pattern
-* qualification ^slicing.discriminator.path = "$this"
+* qualification ^slicing.discriminator.path = "code.coding"
 * qualification ^slicing.rules = #open
 * qualification contains degree 0..*
 
@@ -101,7 +101,7 @@ Description: """Profil de la ressource Practitionner pour la France."""
 
 * qualification[exercicePro] ^short = "exercicePro : exercice professionnel décrivant la profession exercée, l'identité d'exercice d'un professionnel et le cadre de son exercice (civil, militaire, etc.)." 
 * qualification[exercicePro].code.coding ^slicing.discriminator.type = #value
-* qualification[exercicePro].code.coding ^slicing.discriminator.path = "code.coding"
+* qualification[exercicePro].code.coding ^slicing.discriminator.path = "$this"
 * qualification[exercicePro].code.coding ^slicing.rules = #closed
 
 * qualification[exercicePro].code.coding contains 

--- a/input/fsh/profiles/FRCorePractitionerProfile.fsh
+++ b/input/fsh/profiles/FRCorePractitionerProfile.fsh
@@ -71,7 +71,7 @@ Description: """Profil de la ressource Practitionner pour la France."""
 // # DIPLOME #
 // ###########
 
-* qualification ^slicing.discriminator.type = #pattern
+* qualification ^slicing.discriminator.type = #value
 * qualification ^slicing.discriminator.path = "code.coding"
 * qualification ^slicing.rules = #open
 * qualification contains degree 0..*

--- a/input/fsh/profiles/FRCorePractitionerProfile.fsh
+++ b/input/fsh/profiles/FRCorePractitionerProfile.fsh
@@ -72,7 +72,7 @@ Description: """Profil de la ressource Practitionner pour la France."""
 // ###########
 
 * qualification ^slicing.discriminator.type = #value
-* qualification ^slicing.discriminator.path = "code"
+* qualification ^slicing.discriminator.path = "$this"
 * qualification ^slicing.rules = #open
 * qualification contains degree 0..*
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -12,7 +12,7 @@ contact:
         value: fhir@interopsante.org
         use: work
 status: active
-version: 2.1.1-ballot
+version: 2.1.2-ballot
 fhirVersion: 4.0.1
 copyrightYear: 2023+
 releaseLabel: ballot

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -12,7 +12,7 @@ contact:
         value: fhir@interopsante.org
         use: work
 status: active
-version: 2.1.2-ballot
+version: 2.1.0-ballot
 fhirVersion: 4.0.1
 copyrightYear: 2023+
 releaseLabel: ballot

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -12,7 +12,7 @@ contact:
         value: fhir@interopsante.org
         use: work
 status: active
-version: 2.1.0-ballot
+version: 2.1.1-ballot
 fhirVersion: 4.0.1
 copyrightYear: 2023+
 releaseLabel: ballot


### PR DESCRIPTION
## Description des changements | Description of changes made

- Précisions sur le discriminator car le validateur indiquait une erreur (discriminator sur Practitioner.qualification impossible car pas de binding, le binding est sur Practitioner.qualification.code.coding)
- Mise à jour du discriminator de Practitioner.qualification.code.coding également, discriminer sur le system n'étant pas une bonne pratique

## Preview

https://interop-sante.github.io/hl7.fhir.fr.core/nr-update-practitioner-qualification/ig
https://interop-sante.github.io/hl7.fhir.fr.core/nr-update-practitioner-qualification/ig/package.tgz

