### PR TITLE
Update frcore human name use

### DIFF
--- a/input/fsh/datatype-profiles/FRCoreHumanNameProfile.fsh
+++ b/input/fsh/datatype-profiles/FRCoreHumanNameProfile.fsh
@@ -9,10 +9,10 @@ Description: "French profile of datatype HumanName with constraints on prefix an
 * extension ^slicing.rules = #open
 * extension contains $humanname-assembly-order named assemblyOrder 0..1
 
-* use from NameUse (required)
 * prefix ..1
 * prefix from $JDV-J78-Civilite-RASS (extensible)
 * prefix ^binding.description = "Civilités des personnes physiques du RASS"
+
 * suffix from $JDV-J79-CiviliteExercice-RASS (extensible)
 * suffix ^short = "jeu de valeurs pour spécifier le titre de la personne"
 * suffix ^binding.description = "Civilités d'exercice d'un professionnel du RASS"

--- a/input/fsh/profiles/FRCorePatientProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientProfile.fsh
@@ -98,12 +98,13 @@ Description: """Profile of the Patient resource for France. This profile specifi
 // slice usualName laissée à titre d'information
 * name[usualName] ^short = "Name of a human | Nom utilisé"
 * name[usualName] ^definition = "A human's name with the ability to identify parts and usage | Le nom utilisé (usual) n’est transmis que s’il est défini (par exemple nom marital du conjoint)."
-* name[usualName].use 1..
+* name[usualName].use 1..1
 * name[usualName].use = #usual
 
 * name[officialName] ^short = "Name of a human | Nom de naissance"
 * name[officialName] ^definition = "A human's name with the ability to identify parts and usage | Le nom de naissance (official) est obligatoire dans le cas où l’on véhicule l’INS et que l’identité est qualifiée (celui-ci ne doit pas être altéré)."
 * name[officialName] 1..
+* name[officialName].use 1..1
 * name[officialName].use = #official
 * name[officialName].family 1..
 * name[officialName].given 1..

--- a/input/fsh/profiles/FRCorePatientProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientProfile.fsh
@@ -103,7 +103,6 @@ Description: """Profile of the Patient resource for France. This profile specifi
 
 * name[officialName] ^short = "Name of a human | Nom de naissance"
 * name[officialName] ^definition = "A human's name with the ability to identify parts and usage | Le nom de naissance (official) est obligatoire dans le cas où l’on véhicule l’INS et que l’identité est qualifiée (celui-ci ne doit pas être altéré)."
-* name[officialName] 1..
 * name[officialName].use 1..1
 * name[officialName].use = #official
 * name[officialName].family 1..


### PR DESCRIPTION
## Description des changements | Description of changes made

* Suppression lignes inutiles (use from NameUse car déjà dans la spécification FHIR originale,
* Ajout de la ligne .use 1..1 pour rendre transparent l'obligation

## Preview

https://interop-sante.github.io/hl7.fhir.fr.core/[ajouter_nom_de_la_branche]/ig

