### PR TITLE
Définir un profil FHIR Patient de base commun à tous les cas d’usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ Thumbs.db
 # backup files #
 ################
 *.bak
+
+.idea/

--- a/input/fsh/Examples/patient1.fsh
+++ b/input/fsh/Examples/patient1.fsh
@@ -1,24 +1,23 @@
-
-Instance: ExampleFRCorePatient001
+Instance: FRCorePatientExample
 InstanceOf: fr-core-patient-ins
+Description: "Exemple de ressource Patient (cas d'usage INS)"
 Usage: #example
 
 // identityReliability
 * extension[identityReliability].extension[identityStatus].valueCoding = https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0445#VALI
 
 // birthPlace
-* extension[birthPlace].url = "http://hl7.org/fhir/StructureDefinition/patient-birthPlace"
 * extension[birthPlace].valueAddress.extension[inseeCode].valueCoding = https://mos.esante.gouv.fr/NOS/TRE_R13-CommuneOM/FHIR/TRE-R13-CommuneOM#01006
 * extension[birthPlace].valueAddress.city = "Ambléon"
 
 
-* identifier[INS-NIR].use = #official
-* identifier[INS-NIR].system = "urn:oid:1.2.250.1.213.1.4.8"
+//* identifier[INS-NIR].use = #official
+//* identifier[INS-NIR].system = "urn:oid:1.2.250.1.213.1.4.8"
 * identifier[INS-NIR].value = "123456789012244"
 
 * active = true
 
-* name[officialName].use = #official
+//* name[officialName].use = #official
 * name[officialName].family = "Durand"
 * name[officialName].given[0] = "Pierre"
 * name[officialName].extension[birth-list-given-name].valueString = "Pierre Yves"
@@ -26,22 +25,23 @@ Usage: #example
 * telecom[0].use = #home
 * telecom[0].system = #phone
 * telecom[0].value = "01 23 24 67 89"
-* telecom[1].use = #work
-* telecom[1].rank = 1
-* telecom[1].system = #phone
-* telecom[1].value = "01 99 88 77 66"
-* telecom[2].use = #mobile
-* telecom[2].rank = 2
-* telecom[2].system = #phone
-* telecom[2].value = "06 80 55 34 33"
+* telecom[+].use = #work
+* telecom[=].rank = 1
+* telecom[=].system = #phone
+* telecom[=].value = "01 99 88 77 66"
+* telecom[+].use = #mobile
+* telecom[=].rank = 2
+* telecom[=].system = #phone
+* telecom[=].value = "06 80 55 34 33"
 
 * gender = #male
 * birthDate = "1974-12-25"
 * deceasedBoolean = false
-* address.use = #home
-* address.type = #both
-* address.text = "367 rue Troussier, 45100 Orléans, France"
-* address.line = "367 rue Troussier"
-* address.city = "Orléans"
-* address.postalCode = "45100"
-* address.period.start = "2018-06-01"
+* address
+  * use = #home
+  * type = #both
+  * text = "367 rue Troussier, 45100 Orléans, France"
+  * line = "367 rue Troussier"
+  * city = "Orléans"
+  * postalCode = "45100"
+  * period.start = "2018-06-01"

--- a/input/fsh/Examples/patient1.fsh
+++ b/input/fsh/Examples/patient1.fsh
@@ -11,13 +11,10 @@ Usage: #example
 * extension[birthPlace].valueAddress.city = "Ambléon"
 
 
-//* identifier[INS-NIR].use = #official
-//* identifier[INS-NIR].system = "urn:oid:1.2.250.1.213.1.4.8"
 * identifier[INS-NIR].value = "123456789012244"
 
 * active = true
 
-//* name[officialName].use = #official
 * name[officialName].family = "Durand"
 * name[officialName].given[0] = "Pierre"
 * name[officialName].extension[birth-list-given-name].valueString = "Pierre Yves"

--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -70,6 +70,9 @@ Alias: $humanname-assembly-order = http://hl7.org/fhir/StructureDefinition/human
 Alias: $workflow-supportingInfo = http://hl7.org/fhir/StructureDefinition/workflow-supportingInfo
 Alias: $bpMeasBodyLocationPrecoordVS = http://hl7.org/fhir/hspc/ValueSet/bpMeasBodyLocationPrecoordVS
 Alias: $ServiceType = http://terminology.hl7.org/CodeSystem/service-type
+Alias: $patient-birthPlace = http://hl7.org/fhir/StructureDefinition/patient-birthPlace
+Alias: $identifier-use-vs = http://hl7.org/fhir/ValueSet/identifier-use
+Alias: $identifier-use-cs = http://hl7.org/fhir/identifier-use
 
 // opencimi
 Alias: $ValueSet-heartRateMeasMethodVS = http://hl7.org/fhir/hspc/ValueSet/heartRateMeasMethodVS

--- a/input/fsh/profiles/FRCorePatientProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientProfile.fsh
@@ -1,7 +1,7 @@
 Profile: FRCorePatientProfile
 Parent: Patient
 Id: fr-core-patient
-Title: "FR Core Patient Profile"
+Title: "FR Core Patient Profile (All Use Case)"
 Description: """Profile of the Patient resource for France. This profile specifies the patient's identifiers for France. It uses international extensions (birtplace and nationality) and adds specific French extensions.
 \r\nCe profil spécifie les identifiants de patient utilisés en France. Il utilise des extensions internationales (birthplace et nationalité) et ajoute des extensions propres à la France.)"""
 
@@ -20,8 +20,8 @@ Description: """Profile of the Patient resource for France. This profile specifi
     fr-core-patient-nationality named nationality 0..1 and
     FRCorePatientIdentityReliabilityExtension named identityReliability 0..* and 
     FRCorePatientDeathPlaceExtension named deathPlace 0..1 and
-    FRCorePatientBirthdateUpdateIndicatorExtension named birthdateUpdateIndicator 0..1 and
-    http://hl7.org/fhir/StructureDefinition/patient-birthPlace named birthPlace 0..1 and
+    FRCorePatientBirthdateUpdateIndicatorExtension named birthDateUpdateIndicator 0..1 and
+    $patient-birthPlace named birthPlace 0..1 and
     FRCorePatientMultipleBirthExtension named multipleBirth 0..1
 
 * extension[birthPlace].valueAddress only FRCoreAddressProfile
@@ -34,30 +34,45 @@ Description: """Profile of the Patient resource for France. This profile specifi
 * identifier ^slicing.rules = #open
 * identifier ^short = "An identifier for this patient | Identifiant patient. Pour modéliser un patient avec une INS validée, il est nécessaire de respecter la conformité au profil FrCorePatientINS. Les identifiants NIR et NIA ne sont définis uniquement dans le cas du FRCorePatientINS."
 
-
-
 * identifier contains
     NSS 0..1 and
+    INS-NIR 0..* and
+    INS-NIA 0..* and
     INS-C 0..* and
     NDP 0..1 and
     PI 0..* and
     RRI 0..*
 
-
 * identifier[NSS] ^short = "National Health Plan Identifier | Le Numéro d'Inscription au Répertoire (NIR) de facturation permet de faire transiter le numéro de sécurité social de l’ayant droit ou du bénéfiaire (patient) / le numéro de sécurité sociale de l’ouvrant droit (assuré)."
 * identifier[NSS].use 1..
 * identifier[NSS].use = #official
-* identifier[NSS].type 1..
 * identifier[NSS].type = http://terminology.hl7.org/CodeSystem/v2-0203#NH
 * identifier[NSS].system 1..
 * identifier[NSS].system = "urn:oid:1.2.250.1.213.1.4.8"
 * identifier[NSS].value 1..
 
+* identifier[INS-NIR] ^short = "INS-NIR - The patient national health identifier INS obtained by requesting the national patient identification service (CNAM) called the INSi teleservice. Identifiant national de santé (NIR) du patient INS provenant du téléservice INSi (service national d'identification des patients (CNAM))"
+* identifier[INS-NIR].use 1..
+* identifier[INS-NIR].use = #official
+* identifier[INS-NIR].type = $fr-core-v2-0203#INS-NIR
+* identifier[INS-NIR].system 1..
+* identifier[INS-NIR].system = "urn:oid:1.2.250.1.213.1.4.8"
+* identifier[INS-NIR].system ^short = "Autorité d'affectation des INS-NIR"
+* identifier[INS-NIR].value 1..
+
+* identifier[INS-NIA] ^short = "INS-NIA - The temporary patient health national identifier obtained by requesting the national patient identification service (CNAM)| Identifiant national temporaire de santé du patient obtenu par interrogation du téléservice INSi de la CNAM"
+* identifier[INS-NIA].use 1..
+* identifier[INS-NIA].use = #temp
+* identifier[INS-NIA].type = $fr-core-v2-0203#INS-NIA
+* identifier[INS-NIA].system 1..
+* identifier[INS-NIA].system = "urn:oid:1.2.250.1.213.1.4.9"
+* identifier[INS-NIA].system ^short = "Autorité d'affectation des INS-NIA"
+* identifier[INS-NIA].value 1..
+
 * identifier[INS-C] ^short = "Computed National Health Identifier | Identifiant National de Santé Calculé à partir des éléments de la carte vitale"
 * identifier[INS-C].use 1..
 * identifier[INS-C].use = #secondary
-* identifier[INS-C].type 1..
-* identifier[INS-C].type = $fr-core-v2-0203#INS-C "Identifiant National de Santé Calculé"
+* identifier[INS-C].type = $fr-core-v2-0203#INS-C //"Identifiant National de Santé Calculé"
 * identifier[INS-C].system 1..
 * identifier[INS-C].system = "urn:oid:1.2.250.1.213.1.4.2"
 * identifier[INS-C].value 1..
@@ -65,25 +80,24 @@ Description: """Profile of the Patient resource for France. This profile specifi
 * identifier[NDP] ^short = "French pharmaceutical Record Identifier | Numéro de Dossier Pharmaceutique français. Celui-ci est unique."
 * identifier[NDP].use 1..
 * identifier[NDP].use = #secondary
-* identifier[NDP].type 1..
-* identifier[NDP].type = $fr-core-v2-0203#NDP "Identifiant du patient au Dossier Pharmaceutique"
+* identifier[NDP].type = $fr-core-v2-0203#NDP //"Identifiant du patient au Dossier Pharmaceutique"
 * identifier[NDP].system 1..
 * identifier[NDP].system = "urn:oid:1.2.250.1.176.1.2"
 * identifier[NDP].value 1..
 
-* identifier[PI] ^short = "Hospital assigned patient identifier | IPP"
+* identifier[PI] ^short = "Hospital assigned patient identifier | Identifiant Patient Permanent (IPP)."
 * identifier[PI].use 1..
+* identifier[PI].use from FRCoreValueSetPatientIdentifierUse
 * identifier[PI].use = #usual
-* identifier[PI].type 1..
-* identifier[PI].type = http://terminology.hl7.org/CodeSystem/v2-0203#PI "Patient internal identifier"
+* identifier[PI].use ^comment = "La valeur old permet d'identifier des IPP désactivés (en cas de fusion d'identité pour résoudre des problèmes de doublonnage par exemple)"
+* identifier[PI].type = http://terminology.hl7.org/CodeSystem/v2-0203#PI //"Patient internal identifier"
 * identifier[PI].system 1..
 * identifier[PI].value 1..
 
 * identifier[RRI] ^short = "Regional Registry ID | Identifiant régional"
 * identifier[RRI].use 1..
 * identifier[RRI].use = #secondary
-* identifier[RRI].type 1..
-* identifier[RRI].type = http://terminology.hl7.org/CodeSystem/v2-0203#RRI "Regional registry ID"
+* identifier[RRI].type = http://terminology.hl7.org/CodeSystem/v2-0203#RRI //"Regional registry ID"
 * identifier[RRI].system 1..
 * identifier[RRI].value 1..
 
@@ -136,21 +150,21 @@ Description: """Profile of the Patient resource for France. This profile specifi
 
 * contact.relationship ^slicing.rules = #open
 * contact.relationship contains
-    Role 0..1 and
-    RelationType 0..1
+    role 0..1 and
+    relationType 0..1
 // TODO : discuter des cardinalités : relationship, relationship[RolePerson], relationship[RelatedPerson]
 
-* contact.relationship[Role] from FRCoreValueSetPatientContactRole (extensible) 
+* contact.relationship[role] from FRCoreValueSetPatientContactRole (extensible) 
 //TODO : à confirmer car HL7 préconise un autre VS, à mettre à jour, utiliser FRCoreValueSetContactRelationship ?
 //TODO : Adapter aux valeurs préconisées dans PAM
-* contact.relationship[Role] ^short = "The nature of the relationship. Rôle de la personne. Ex : personne de confiance, aidant ..."
+* contact.relationship[role] ^short = "The nature of the relationship. Rôle de la personne. Ex : personne de confiance, aidant ..."
 
-* contact.relationship[RelationType] from FRCoreValueSetPatientRelationType (extensible) 
+* contact.relationship[relationType] from FRCoreValueSetPatientRelationType (extensible) 
 //TODO : à confirmer car HL7 préconise un autre VS, à mettre à jour, utiliser FRCoreValueSetContactRelationship ?
 //TODO : Adapter aux valeurs préconisées dans PAM
-* contact.relationship[RelationType] ^short = "The nature of the relationship. Relation de la personne. Ex : Mère, époux, enfant ..."
+* contact.relationship[relationType] ^short = "The nature of the relationship. Relation de la personne. Ex : Mère, époux, enfant ..."
 
 * contact.name only FRCoreHumanNameProfile
 * contact.telecom only FRCoreContactPointProfile
-* generalPractitioner only Reference(FRCorePractitionerProfile or FRCoreOrganizationProfile or PractitionerRole)
-* managingOrganization only Reference(FRCoreOrganizationProfile)
+* generalPractitioner only Reference(FRCorePractitionerProfile or FRCoreOrganizationProfile or Practitioner or Organization or PractitionerRole)
+* managingOrganization only Reference(FRCoreOrganizationProfile or Organization)

--- a/input/fsh/profiles/FrCorePatientINSProfile.fsh
+++ b/input/fsh/profiles/FrCorePatientINSProfile.fsh
@@ -6,7 +6,8 @@ Description: """Profil Fr Core Patient surspécifié pour être conforme aux exi
 
 * obeys fr-core-1 
 
-* meta.profile contains fr-ins-canonical 0..1
+* meta.profile contains 
+    fr-ins-canonical 0..1
 * meta.profile[fr-ins-canonical] = Canonical(fr-core-patient-ins)
 
 
@@ -19,54 +20,31 @@ Description: """Profil Fr Core Patient surspécifié pour être conforme aux exi
 * identifier 1..
 
 * identifier contains
-    INS-NIR 0..* and
     INS-NIR-TEST 0..* and
-    INS-NIR-DEMO 0..* and
-    INS-NIA 0..*
+    INS-NIR-DEMO 0..*
 
 // Slices définies dans PatientINS car ne peuvent pas être véhiculé si identité non qualifiée.
-
-* identifier[INS-NIR] ^short = "INS-NIR - The patient national health identifier INS obtained by requesting the national patient identification service (CNAM) called the INSi teleservice. Identifiant national de santé (NIR) du patient INS provenant du téléservice INSi (service national d'identification des patients (CNAM))"
 * identifier[INS-NIR] MS
-* identifier[INS-NIR].use 1..
-* identifier[INS-NIR].use = #official
-* identifier[INS-NIR].type 1..
-* identifier[INS-NIR].type = $fr-core-v2-0203#INS-NIR
-* identifier[INS-NIR].system 1..
-* identifier[INS-NIR].system = "urn:oid:1.2.250.1.213.1.4.8"
-* identifier[INS-NIR].system ^short = "Autorité d'affectation des INS-NIR"
-* identifier[INS-NIR].value 1..
 
 * identifier[INS-NIR-TEST] ^short = "Identifiant INS-NIR du patient fictif de test"
 * identifier[INS-NIR-TEST].use 1..
 * identifier[INS-NIR-TEST].use = #official
-* identifier[INS-NIR-TEST].type 1..
 * identifier[INS-NIR-TEST].type = $fr-core-v2-0203#INS-NIR-TEST
 * identifier[INS-NIR-TEST].system 1..
 * identifier[INS-NIR-TEST].system = "urn:oid:1.2.250.1.213.1.4.10"
-* identifier[INS-NIR-TEST].system ^short = "Autorité d’affectation des INS-NIR de test"
+* identifier[INS-NIR-TEST].system ^short = "Autorité d'affectation des INS-NIR de test"
 * identifier[INS-NIR-TEST].value 1..
 
 * identifier[INS-NIR-DEMO] ^short = "Identifiant INS-NIR du patient fictif de démonstration"
 * identifier[INS-NIR-DEMO].use 1..
 * identifier[INS-NIR-DEMO].use = #official
-* identifier[INS-NIR-DEMO].type 1..
 * identifier[INS-NIR-DEMO].type = $fr-core-v2-0203#INS-NIR-DEMO
 * identifier[INS-NIR-DEMO].system 1..
 * identifier[INS-NIR-DEMO].system = "urn:oid:1.2.250.1.213.1.4.11"
-* identifier[INS-NIR-DEMO].system ^short = "Autorité d’affectation des INS-NIR de démonstration"
+* identifier[INS-NIR-DEMO].system ^short = "Autorité d'affectation des INS-NIR de démonstration"
 * identifier[INS-NIR-DEMO].value 1..
 
-* identifier[INS-NIA] ^short = "INS-NIA - The temporary patient health national identifier obtained by requesting the national patient identification service (CNAM)| Identifiant national temporaire de santé du patient obtenu par interrogation du téléservice INSi de la CNAM"
 * identifier[INS-NIA] MS
-* identifier[INS-NIA].use 1..
-* identifier[INS-NIA].use = #temp
-* identifier[INS-NIA].type 1..
-* identifier[INS-NIA].type = $fr-core-v2-0203#INS-NIA
-* identifier[INS-NIA].system 1..
-* identifier[INS-NIA].system = "urn:oid:1.2.250.1.213.1.4.9"
-* identifier[INS-NIA].system ^short = "Autorité d'affectation des INS-NIA"
-* identifier[INS-NIA].value 1..
 
 * gender 1..1 MS
 * gender from fr-core-vs-patient-gender-INS (required)
@@ -76,12 +54,10 @@ Description: """Profil Fr Core Patient surspécifié pour être conforme aux exi
 
 * name[officialName] 1..1 MS
 * name[officialName].given 1..1
-* name[officialName].given ^short = "Dans le cas d’une identité créée ou modifiée par un appel au téléservice INSi, il est nécessaire d’extraire le premier prénom de la liste des prénoms retournée par le téléservice et de l'inclure dans le champs given. En cas de prénom composé, given peut par exemple contenir 'Anne-sophie' ou 'Anne Sophie'."
-
+* name[officialName].given ^short = "Dans le cas d'une identité créée ou modifiée par un appel au téléservice INSi, il est nécessaire d'extraire le premier prénom de la liste des prénoms retournée par le téléservice et de l'inclure dans le champs given. En cas de prénom composé, given peut par exemple contenir 'Anne-sophie' ou 'Anne Sophie'."
 * name[officialName].extension[birth-list-given-name] 1..1 MS
 
-
 Invariant:   fr-core-1
-Description: "If identityReliability status = 'VALI', then at least Patient.identifier[INS-NIR] or Patient.identifier[INS-NIA] or Patient.identifier[INS-NIR-TEST]or Patient.identifier[INS-NIR-DEMO] SHALL be present"
+Description: "If identityReliability status = 'VALI', then at least Patient.identifier[INS-NIR] or Patient.identifier[INS-NIA] or Patient.identifier[INS-NIR-TEST]or Patient.identifier[INS-NIR-DEMO] SHALL be present"
 * severity = #error
 * expression = "(extension.where(url= 'https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-identity-reliability').extension.where(url = 'identityStatus').value.code = 'VALI') implies (identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.8').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.9').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.10').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.11').exists())"

--- a/input/fsh/valuesets/FRCoreValueSetPatientIdentifierUse.fsh
+++ b/input/fsh/valuesets/FRCoreValueSetPatientIdentifierUse.fsh
@@ -1,0 +1,14 @@
+ValueSet: FRCoreValueSetPatientIdentifierUse
+Id: fr-core-vs-patient-identifier-use
+Title: "FR Core ValueSet Patient identifier use"
+Description: """
+Use autorisés pour les identifiants patients attribués par les hôpitaux (IPP).
+Authorized use for PI identifier.
+"""
+
+* ^meta.profile = $shareablevalueset
+// SVS profile
+* ^experimental = false
+
+* include codes from valueset $identifier-use-vs
+* exclude $identifier-use-cs#official


### PR DESCRIPTION
## Description des changements | Description of changes made

* définir un profil FHIR Patient de base commun à tous les cas d’usage

Proposition d’un profil FHIR Patient de base, destiné à servir de référence unique et point de départ pour tous les profils Patient spécifiques.

Ce profil standardise les éléments fondamentaux (identifiants, nom, sexe, date de naissance, extensions génériques, etc.) afin d’assurer la cohérence, l’harmonisation et la réutilisabilité dans l’ensemble des cas d’usage métier.

## Preview

https://interop-sante.github.io/hl7.fhir.fr.core/[ajouter_nom_de_la_branche]/ig

