### PR TITLE
Relaxation de la contrainte Encounter.subject pour qu'il puisse également pointer un Group

### DIFF
--- a/input/fsh/profiles/FRCoreEncounterProfile.fsh
+++ b/input/fsh/profiles/FRCoreEncounterProfile.fsh
@@ -46,7 +46,7 @@ Ce profil de la ressource Encounter sert à la fois à définir la venue dans l'
 * type from FRCoreValueSetEncounterType (example)
 * type ^binding.extension[0].url = "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName"
 * type ^binding.extension[=].valueString = "EncounterType"
-* subject only Reference(FRCorePatientProfile) or Reference(Group)
+* subject only Reference(FRCorePatientProfile or Group)
 * participant ^short = "List of participants involved in the encounter | Liste des personnes impliquées dans la rencontre"
 * participant.individual only Reference(RelatedPerson or FRCorePractitionerProfile or PractitionerRole)
 * appointment only Reference(FRCoreAppointmentProfile)

--- a/input/fsh/profiles/FRCoreEncounterProfile.fsh
+++ b/input/fsh/profiles/FRCoreEncounterProfile.fsh
@@ -46,7 +46,7 @@ Ce profil de la ressource Encounter sert à la fois à définir la venue dans l'
 * type from FRCoreValueSetEncounterType (example)
 * type ^binding.extension[0].url = "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName"
 * type ^binding.extension[=].valueString = "EncounterType"
-* subject only Reference(FRCorePatientProfile)
+* subject only Reference(FRCorePatientProfile) or Reference(Group)
 * participant ^short = "List of participants involved in the encounter | Liste des personnes impliquées dans la rencontre"
 * participant.individual only Reference(RelatedPerson or FRCorePractitionerProfile or PractitionerRole)
 * appointment only Reference(FRCoreAppointmentProfile)


### PR DESCRIPTION
## Description des changements | Description of changes made

* Autorisation qu'un Encounter puisse concerner plusieurs patients via une ressource Group.
* Utilisation dans le cadre des activités du médicosocial

## Preview

https://interop-sante.github.io/hl7.fhir.fr.core/nr-add-encounter-group/ig

