### PR TITLE
Mise à jour des identifiants du PatientINS

### DIFF
--- a/input/fsh/profiles/FRCorePatientINSProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientINSProfile.fsh
@@ -31,6 +31,7 @@ Description: """Profil Fr Core Patient surspécifié pour être conforme aux exi
 * identifier[INS-NIR] MS
 * identifier[INS-NIR].use 1..
 * identifier[INS-NIR].use from FRCoreValueSetPatientIdentifierUseINS
+* identifier[INS-NIR].use ^short = "official | old"
 * identifier[INS-NIR].use ^comment = "La valeur old permet d'identifier des INS désactivés (permettant de noter l'ancien INS-NIR en cas de changement de sexe par exemple)"
 * identifier[INS-NIR].type 1..
 * identifier[INS-NIR].type = $fr-core-v2-0203#INS-NIR
@@ -42,8 +43,8 @@ Description: """Profil Fr Core Patient surspécifié pour être conforme aux exi
 * identifier[INS-NIA] ^short = "INS-NIA - The temporary patient health national identifier obtained by requesting the national patient identification service (CNAM)| Identifiant national temporaire de santé du patient obtenu par interrogation du téléservice INSi de la CNAM"
 * identifier[INS-NIA] MS
 * identifier[INS-NIA].use 1..
-* identifier[INS-NIA].use = #temp
 * identifier[INS-NIA].use from FRCoreValueSetPatientIdentifierUseINS
+* identifier[INS-NIA].use ^short = "official | old"
 * identifier[INS-NIA].use ^comment = "La valeur old permet d'identifier des INS désactivés (en cas d'obtention d'un INS-NIR par exemple)"
 * identifier[INS-NIA].type 1..
 * identifier[INS-NIA].type = $fr-core-v2-0203#INS-NIA
@@ -89,7 +90,7 @@ Description: """Profil Fr Core Patient surspécifié pour être conforme aux exi
 Invariant:   fr-core-1
 Description: "If identityReliability status = 'VALI', then at least Patient.identifier[INS-NIR] or Patient.identifier[INS-NIA] or Patient.identifier[INS-NIR-TEST]or Patient.identifier[INS-NIR-DEMO] SHALL be present"
 * severity = #error
-* expression = "(extension('https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-identity-reliability').extension('identityStatus').value.exists(code = 'VALI')) implies (identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.8' and use = 'official').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.9' and use = 'temp').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.10' and use = 'official').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.11' and use = 'official').exists())"
+* expression = "(extension('https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-identity-reliability').extension('identityStatus').value.exists(code = 'VALI')) implies (identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.8' and use = 'official').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.9' and use = 'official').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.10' and use = 'official').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.11' and use = 'official').exists())"
 
 Invariant:   fr-core-2
 Description: "If identityReliability status = 'VALI', then only one identifier of type official SHALL be present"

--- a/input/fsh/profiles/FRCorePatientINSProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientINSProfile.fsh
@@ -10,8 +10,9 @@ Description: """Profil Fr Core Patient surspécifié pour être conforme aux exi
 * meta.profile contains fr-ins-canonical 0..1
 * meta.profile[fr-ins-canonical] = Canonical(fr-core-patient-ins)
 
+* extension[identityReliability].extension[identityStatus] = #VALI 
+* extension[identityReliability].extension[validationMode] only fr-core-vs-mode-validation-identity-ins (required)
 
-* extension[identityReliability] 1..*
 
 * extension[birthPlace] 1..1
 * extension[birthPlace] MS
@@ -30,7 +31,7 @@ Description: """Profil Fr Core Patient surspécifié pour être conforme aux exi
 * identifier[INS-NIR] ^short = "INS-NIR - The patient national health identifier INS obtained by requesting the national patient identification service (CNAM) called the INSi teleservice. Identifiant national de santé (NIR) du patient INS provenant du téléservice INSi (service national d'identification des patients (CNAM))"
 * identifier[INS-NIR] MS
 * identifier[INS-NIR].use 1..
-* identifier[INS-NIR].use from FRCoreValueSetPatientIdentifierUseINS
+* identifier[INS-NIR].use from FRCoreValueSetPatientIdentifierUseINS  (required)
 * identifier[INS-NIR].use ^short = "official | old"
 * identifier[INS-NIR].use ^comment = "La valeur old permet d'identifier des INS désactivés (permettant de noter l'ancien INS-NIR en cas de changement de sexe par exemple)"
 * identifier[INS-NIR].type 1..
@@ -43,9 +44,9 @@ Description: """Profil Fr Core Patient surspécifié pour être conforme aux exi
 * identifier[INS-NIA] ^short = "INS-NIA - The temporary patient health national identifier obtained by requesting the national patient identification service (CNAM)| Identifiant national temporaire de santé du patient obtenu par interrogation du téléservice INSi de la CNAM"
 * identifier[INS-NIA] MS
 * identifier[INS-NIA].use 1..
-* identifier[INS-NIA].use from FRCoreValueSetPatientIdentifierUseINS
+* identifier[INS-NIA].use from FRCoreValueSetPatientIdentifierUseINS (required)
 * identifier[INS-NIA].use ^short = "official | old"
-* identifier[INS-NIA].use ^comment = "La valeur old permet d'identifier des INS désactivés (en cas d'obtention d'un INS-NIR par exemple)"
+* identifier[INS-NIA].use ^comment = "Un INS d'attente est à la fois officiel et temporaire. Pour éviter les différences d'interprétation, il a été conclu en 2025 que l'INS-NIA est avant tout le numéro officiel à un instant donné. La valeur old permet d'identifier des INS désactivés (en cas d'obtention d'un INS-NIR par exemple)"
 * identifier[INS-NIA].type 1..
 * identifier[INS-NIA].type = $fr-core-v2-0203#INS-NIA
 * identifier[INS-NIA].system 1..

--- a/input/fsh/profiles/FRCorePatientINSProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientINSProfile.fsh
@@ -5,6 +5,7 @@ Title: "FR Core Patient INS Profile"
 Description: """Profil Fr Core Patient surspécifié pour être conforme aux exigences du référentiel d'Identité Nationale de Santé (INS). Le matricule INS ne peut être véhiculé que dans le cas d'une identité qualifiée, raison pour laquelle les slices identifier sont définies au niveau du FRCorePatientINS et non au niveau du FRCorePatient."""
 
 * obeys fr-core-1 
+* obeys fr-core-2
 
 * meta.profile contains fr-ins-canonical 0..1
 * meta.profile[fr-ins-canonical] = Canonical(fr-core-patient-ins)
@@ -29,13 +30,28 @@ Description: """Profil Fr Core Patient surspécifié pour être conforme aux exi
 * identifier[INS-NIR] ^short = "INS-NIR - The patient national health identifier INS obtained by requesting the national patient identification service (CNAM) called the INSi teleservice. Identifiant national de santé (NIR) du patient INS provenant du téléservice INSi (service national d'identification des patients (CNAM))"
 * identifier[INS-NIR] MS
 * identifier[INS-NIR].use 1..
-* identifier[INS-NIR].use = #official
+* identifier[INS-NIR].use from FRCoreValueSetPatientIdentifierUseINS
+* identifier[INS-NIR].use ^comment = "La valeur old permet d'identifier des INS désactivés (en cas de fusion d'identité pour résoudre des problèmes de doublonnage par exemple)"
 * identifier[INS-NIR].type 1..
 * identifier[INS-NIR].type = $fr-core-v2-0203#INS-NIR
 * identifier[INS-NIR].system 1..
 * identifier[INS-NIR].system = "urn:oid:1.2.250.1.213.1.4.8"
 * identifier[INS-NIR].system ^short = "Autorité d'affectation des INS-NIR"
 * identifier[INS-NIR].value 1..
+
+* identifier[INS-NIA] ^short = "INS-NIA - The temporary patient health national identifier obtained by requesting the national patient identification service (CNAM)| Identifiant national temporaire de santé du patient obtenu par interrogation du téléservice INSi de la CNAM"
+* identifier[INS-NIA] MS
+* identifier[INS-NIA].use 1..
+* identifier[INS-NIA].use = #temp
+* identifier[INS-NIR].use from FRCoreValueSetPatientIdentifierUseINS
+* identifier[INS-NIR].use ^comment = "La valeur old permet d'identifier des INS désactivés (en cas de fusion d'identité pour résoudre des problèmes de doublonnage par exemple)"
+* identifier[INS-NIA].type 1..
+* identifier[INS-NIA].type = $fr-core-v2-0203#INS-NIA
+* identifier[INS-NIA].system 1..
+* identifier[INS-NIA].system = "urn:oid:1.2.250.1.213.1.4.9"
+* identifier[INS-NIA].system ^short = "Autorité d'affectation des INS-NIA"
+* identifier[INS-NIA].value 1..
+
 
 * identifier[INS-NIR-TEST] ^short = "Identifiant INS-NIR du patient fictif de test"
 * identifier[INS-NIR-TEST].use 1..
@@ -57,17 +73,6 @@ Description: """Profil Fr Core Patient surspécifié pour être conforme aux exi
 * identifier[INS-NIR-DEMO].system ^short = "Autorité d’affectation des INS-NIR de démonstration"
 * identifier[INS-NIR-DEMO].value 1..
 
-* identifier[INS-NIA] ^short = "INS-NIA - The temporary patient health national identifier obtained by requesting the national patient identification service (CNAM)| Identifiant national temporaire de santé du patient obtenu par interrogation du téléservice INSi de la CNAM"
-* identifier[INS-NIA] MS
-* identifier[INS-NIA].use 1..
-* identifier[INS-NIA].use = #temp
-* identifier[INS-NIA].type 1..
-* identifier[INS-NIA].type = $fr-core-v2-0203#INS-NIA
-* identifier[INS-NIA].system 1..
-* identifier[INS-NIA].system = "urn:oid:1.2.250.1.213.1.4.9"
-* identifier[INS-NIA].system ^short = "Autorité d'affectation des INS-NIA"
-* identifier[INS-NIA].value 1..
-
 * gender 1..1 MS
 * gender from fr-core-vs-patient-gender-INS (required)
 * gender ^short = "male | female | unknown"
@@ -84,4 +89,9 @@ Description: """Profil Fr Core Patient surspécifié pour être conforme aux exi
 Invariant:   fr-core-1
 Description: "If identityReliability status = 'VALI', then at least Patient.identifier[INS-NIR] or Patient.identifier[INS-NIA] or Patient.identifier[INS-NIR-TEST]or Patient.identifier[INS-NIR-DEMO] SHALL be present"
 * severity = #error
-* expression = "(extension('https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-identity-reliability').extension('identityStatus').value.exists(code = 'VALI')) implies (identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.8').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.9').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.10').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.11').exists())"
+* expression = "(extension('https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-identity-reliability').extension('identityStatus').value.exists(code = 'VALI')) implies (identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.8' and use = 'official').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.9' and use = 'temp').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.10' and use = 'official').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.11' and use = 'official').exists())"
+
+Invariant:   fr-core-2
+Description: "If identityReliability status = 'VALI', then it should be only one official identifier"
+* severity = #error
+* expression = "(extension('https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-identity-reliability').extension('identityStatus').value.exists(code = 'VALI')) implies (identifier.where(use = 'official').count() = 1 or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.9' and use = 'temp').exists())"

--- a/input/fsh/profiles/FRCorePatientINSProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientINSProfile.fsh
@@ -92,6 +92,6 @@ Description: "If identityReliability status = 'VALI', then at least Patient.ide
 * expression = "(extension('https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-identity-reliability').extension('identityStatus').value.exists(code = 'VALI')) implies (identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.8' and use = 'official').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.9' and use = 'temp').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.10' and use = 'official').exists() or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.11' and use = 'official').exists())"
 
 Invariant:   fr-core-2
-Description: "If identityReliability status = 'VALI', then it should be only one official identifier"
+Description: "If identityReliability status = 'VALI', then only one identifier of type official SHALL be present"
 * severity = #error
 * expression = "(extension('https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-identity-reliability').extension('identityStatus').value.exists(code = 'VALI')) implies (identifier.where(use = 'official').count() = 1 or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.9' and use = 'temp').exists())"

--- a/input/fsh/profiles/FRCorePatientINSProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientINSProfile.fsh
@@ -31,7 +31,7 @@ Description: """Profil Fr Core Patient surspécifié pour être conforme aux exi
 * identifier[INS-NIR] MS
 * identifier[INS-NIR].use 1..
 * identifier[INS-NIR].use from FRCoreValueSetPatientIdentifierUseINS
-* identifier[INS-NIR].use ^comment = "La valeur old permet d'identifier des INS désactivés (en cas de fusion d'identité pour résoudre des problèmes de doublonnage par exemple)"
+* identifier[INS-NIR].use ^comment = "La valeur old permet d'identifier des INS désactivés (permettant de noter l'ancien INS-NIR en cas de changement de sexe par exemple)"
 * identifier[INS-NIR].type 1..
 * identifier[INS-NIR].type = $fr-core-v2-0203#INS-NIR
 * identifier[INS-NIR].system 1..
@@ -43,8 +43,8 @@ Description: """Profil Fr Core Patient surspécifié pour être conforme aux exi
 * identifier[INS-NIA] MS
 * identifier[INS-NIA].use 1..
 * identifier[INS-NIA].use = #temp
-* identifier[INS-NIR].use from FRCoreValueSetPatientIdentifierUseINS
-* identifier[INS-NIR].use ^comment = "La valeur old permet d'identifier des INS désactivés (en cas de fusion d'identité pour résoudre des problèmes de doublonnage par exemple)"
+* identifier[INS-NIA].use from FRCoreValueSetPatientIdentifierUseINS
+* identifier[INS-NIA].use ^comment = "La valeur old permet d'identifier des INS désactivés (en cas d'obtention d'un INS-NIR par exemple)"
 * identifier[INS-NIA].type 1..
 * identifier[INS-NIA].type = $fr-core-v2-0203#INS-NIA
 * identifier[INS-NIA].system 1..

--- a/input/fsh/profiles/FRCorePatientINSProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientINSProfile.fsh
@@ -95,4 +95,4 @@ Description: "If identityReliability status = 'VALI', then at least Patient.ide
 Invariant:   fr-core-2
 Description: "If identityReliability status = 'VALI', then only one identifier of type official SHALL be present"
 * severity = #error
-* expression = "(extension('https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-identity-reliability').extension('identityStatus').value.exists(code = 'VALI')) implies (identifier.where(use = 'official').count() = 1 or identifier.where(system = 'urn:oid:1.2.250.1.213.1.4.9' and use = 'temp').exists())"
+* expression = "(extension('https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-identity-reliability').extension('identityStatus').value.exists(code = 'VALI')) implies (identifier.where(use = 'official').count() = 1).exists())"

--- a/input/fsh/profiles/FRCorePatientProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientProfile.fsh
@@ -41,7 +41,6 @@ Description: """Profile of the Patient resource for France. This profile specifi
     PI 0..* and
     RRI 0..*
 
-
 * identifier[NSS] ^short = "National Health Plan Identifier | Le Numéro d'Inscription au Répertoire (NIR) de facturation permet de faire transiter le numéro de sécurité social de l’ayant droit ou du bénéfiaire (patient) / le numéro de sécurité sociale de l’ouvrant droit (assuré)."
 * identifier[NSS].use 1..
 * identifier[NSS].use = #official
@@ -71,7 +70,7 @@ Description: """Profile of the Patient resource for France. This profile specifi
 
 * identifier[PI] ^short = "Hospital assigned patient identifier | Identifiant Patient Permanent (IPP)."
 * identifier[PI].use 1..
-* identifier[PI].use from FRCoreValueSetPatientIdentifierUse
+* identifier[PI].use from FRCoreValueSetPatientIdentifierUsePI
 * identifier[PI].use ^comment = "La valeur old permet d'identifier des IPP désactivés (en cas de fusion d'identité pour résoudre des problèmes de doublonnage par exemple)"
 * identifier[PI].type 1..
 * identifier[PI].type = http://terminology.hl7.org/CodeSystem/v2-0203#PI "Patient internal identifier"

--- a/input/fsh/valuesets/FRCoreValueSetModeValidationIdentityINS.fsh
+++ b/input/fsh/valuesets/FRCoreValueSetModeValidationIdentityINS.fsh
@@ -1,0 +1,12 @@
+ValueSet: FRCoreValueSetModeValidationIdentityINS
+Id: fr-core-vs-mode-validation-identity-ins
+Title: "FR Core ValueSet Mode validation identity INS"
+Description: "The validation mode of the identity authorized for INS"
+* ^meta.profile = "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
+// SVS profile
+* ^experimental = false
+
+* fr-core-cs-mode-validation-identity#PA
+* fr-core-cs-mode-validation-identity#CN
+* fr-core-cs-mode-validation-identity#AN
+* fr-core-cs-mode-validation-identity#LE

--- a/input/fsh/valuesets/FRCoreValueSetPatientIdentifierUseINS.fsh
+++ b/input/fsh/valuesets/FRCoreValueSetPatientIdentifierUseINS.fsh
@@ -1,0 +1,12 @@
+ValueSet: FRCoreValueSetPatientIdentifierUseINS
+Id: fr-core-vs-patient-identifier-use-ins
+Title: "FR Core ValueSet Patient identifier use INS"
+Description: "Use autorisés pour l'identifiant national de santé.\r\nAuthorized use for INS identifier."
+
+* ^meta.profile = "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
+
+* include http://hl7.org/fhir/identifier-use#official
+* include http://hl7.org/fhir/identifier-use#old
+
+// SVS profile
+* ^experimental = false

--- a/input/fsh/valuesets/FRCoreValueSetPatientIdentifierUsePI.fsh
+++ b/input/fsh/valuesets/FRCoreValueSetPatientIdentifierUsePI.fsh
@@ -1,6 +1,6 @@
-ValueSet: FRCoreValueSetPatientIdentifierUse
-Id: fr-core-vs-patient-identifier-use
-Title: "FR Core ValueSet Patient identifier use"
+ValueSet: FRCoreValueSetPatientIdentifierUsePI
+Id: fr-core-vs-patient-identifier-use-pi
+Title: "FR Core ValueSet Patient identifier use PI"
 Description: "Use autorisés pour les identifiants patients attribués par les hôpitaux (IPP).\r\nAuthorized use for PI identifier."
 
 * ^meta.profile = "http://hl7.org/fhir/StructureDefinition/shareablevalueset"


### PR DESCRIPTION
## Description des changements | Description of changes made

* Ajout d'invariant : le patient peut avoir un unique INS officiel (NIR ou NIA)
* Ajout du ValueSet : le patient peut avoir 0, 1 ou plusieurs identifiants INS-NIR dont le use est old (pour partager les anciens identifiants)
* 


## Preview

https://interop-sante.github.io/hl7.fhir.fr.core/nr-update-patient-identifiers/ig


Je suis preneur de vos reviews @Rosnyni @aperie07
