### PR TITLE
Retrait du genre "other" sur le profil FrCorePatient INS

### DIFF
--- a/input/fsh/profiles/FRCorePatientINSProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientINSProfile.fsh
@@ -76,8 +76,6 @@ Description: """Profil Fr Core Patient surspécifié pour être conforme aux exi
 * identifier[INS-NIR-DEMO].value 1..
 
 * gender 1..1 MS
-* gender from fr-core-vs-patient-gender-INS (required)
-* gender ^short = "male | female | unknown"
 
 * birthDate 1.. MS
 

--- a/input/fsh/profiles/FRCorePatientProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientProfile.fsh
@@ -116,7 +116,7 @@ Description: """Profile of the Patient resource for France. This profile specifi
 
 * gender from fr-core-vs-patient-gender (required)
 * gender ^short = "male | female | unknown"
-* gender ^definition = "French patient's gender checked with the INSi teleservice | Genre administratif du patient. Dans le cas d'une identité récupérée par le téléservice INSi, les valeurs M ou F issues du téléservice sont à adapter à FHIR (male ou female)."
+* gender ^definition = "French patient's gender checked with the INSi teleservice | Genre administratif du patient. Dans le cas d'une identité récupérée par le téléservice INSi, les valeurs M ou F issues du téléservice sont à adapter à FHIR (male | female | unknown)."
 
 * birthDate ^short = "The date of birth for the french patient checked with the INSitelservice | Date de naissance du patient. Dans le cas d'une identité récupérée du téléservice INSi, la date de naissance est modifiée selon les règles du RNIV dans le cas de dates exceptionnelles."
 

--- a/input/fsh/profiles/FRCorePatientProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientProfile.fsh
@@ -116,7 +116,7 @@ Description: """Profile of the Patient resource for France. This profile specifi
 
 * gender from fr-core-vs-patient-gender (required)
 * gender ^short = "male | female | unknown"
-* gender ^definition = "French patient's gender checked with the INSi teleservice | Genre du patient. Dans le cas d'une identité récupérée par le téléservice INSi, les valeurs sont M ou F et à adapter à FHIR (male ou female)."
+* gender ^definition = "French patient's gender checked with the INSi teleservice | Genre administratif du patient. Dans le cas d'une identité récupérée par le téléservice INSi, les valeurs M ou F issues du téléservice sont à adapter à FHIR (male ou female)."
 
 * birthDate ^short = "The date of birth for the french patient checked with the INSitelservice | Date de naissance du patient. Dans le cas d'une identité récupérée du téléservice INSi, la date de naissance est modifiée selon les règles du RNIV dans le cas de dates exceptionnelles."
 

--- a/input/fsh/profiles/FRCorePatientProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientProfile.fsh
@@ -114,7 +114,9 @@ Description: """Profile of the Patient resource for France. This profile specifi
 
 * telecom only FRCoreContactPointProfile
 
-* gender ^definition = "French patient's gender checked with the INSi teleservice | Genre du patient. Dans le cas d'une identité récupérée par le téléservice INSi, les valeurs sont M ou F"
+* gender from fr-core-vs-patient-gender-INS (required)
+* gender ^short = "male | female | unknown"
+* gender ^definition = "French patient's gender checked with the INSi teleservice | Genre du patient. Dans le cas d'une identité récupérée par le téléservice INSi, les valeurs sont M ou F et à adapter à FHIR (male ou female)."
 
 * birthDate ^short = "The date of birth for the french patient checked with the INSitelservice | Date de naissance du patient. Dans le cas d'une identité récupérée du téléservice INSi, la date de naissance est modifiée selon les règles du RNIV dans le cas de dates exceptionnelles."
 

--- a/input/fsh/profiles/FRCorePatientProfile.fsh
+++ b/input/fsh/profiles/FRCorePatientProfile.fsh
@@ -114,7 +114,7 @@ Description: """Profile of the Patient resource for France. This profile specifi
 
 * telecom only FRCoreContactPointProfile
 
-* gender from fr-core-vs-patient-gender-INS (required)
+* gender from fr-core-vs-patient-gender (required)
 * gender ^short = "male | female | unknown"
 * gender ^definition = "French patient's gender checked with the INSi teleservice | Genre du patient. Dans le cas d'une identité récupérée par le téléservice INSi, les valeurs sont M ou F et à adapter à FHIR (male ou female)."
 

--- a/input/fsh/valuesets/FRCoreValueSetPatientGenderINS.fsh
+++ b/input/fsh/valuesets/FRCoreValueSetPatientGenderINS.fsh
@@ -1,7 +1,7 @@
-ValueSet: FRCoreValueSetPatientGenderINS
-Id: fr-core-vs-patient-gender-INS
-Title: "FR Core ValueSet Patient gender INS"
-Description: "Genres autorisés dans le cadre du Patient INS.\r\nPermitted genders for INS Patient"
+ValueSet: FRCoreValueSetPatientGender
+Id: fr-core-vs-patient-gender
+Title: "FR Core ValueSet Patient gender"
+Description: "Genres autorisés dans le cadre du genre administratif du Patient en France. Pour partager des genres suplémentaires (ex. biologique), cf gender harmony implementation guide.\r\nPermitted genders for French Patient gender."
 * ^meta.profile = "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
 
 * include http://hl7.org/fhir/administrative-gender#male


### PR DESCRIPTION
## Description des changements | Description of changes made

* Retrait du genre "other" sur le profil FrCorePatient INS
* Mise en valeur de l'IG Gender Harmony (https://build.fhir.org/ig/HL7/fhir-gender-harmony)

## Preview

https://interop-sante.github.io/hl7.fhir.fr.core/nr-update-patient-gender/ig

