### PR TITLE
Suppression de la contrainte de cardinalité sur Encounter.type

### DIFF
--- a/input/fsh/profiles/FRCoreEncounterProfile.fsh
+++ b/input/fsh/profiles/FRCoreEncounterProfile.fsh
@@ -42,7 +42,6 @@ Ce profil de la ressource Encounter sert à la fois à définir la venue dans l'
 
 * class.system 1..
 * class.code 1..
-* type ..1
 * type from FRCoreValueSetEncounterType (example)
 * type ^binding.extension[0].url = "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName"
 * type ^binding.extension[=].valueString = "EncounterType"


### PR DESCRIPTION
Removed type cardinality constraint from the profile FRCoreEncounter

Discussion GT InteropSanté février 2026

Aujourd’hui, FRCoreEncounterProfile mime la venue du cas d’usage PAM en FHIR et n’est pas générique.

Un GT sur IHE PAM va commencer. L’objectif est de laisser comme tel aujourd’hui avec comme trajectoire 
- Avoir un profil générique FR Core Encounter pas trop contraignant au niveau de l’IG FR Core
-Avoir un profil spécifique + contraignant spécifique de la venue dans le guide « IHE PAM en FHIR », qui hériterait de FRCoreEncounterProfile


## Description des changements | Description of changes made
## Preview

https://interop-sante.github.io/hl7.fhir.fr.core/[ajouter_nom_de_la_branche]/ig

