### PR TITLE
feat(#297): refonte modélisation opérateur Appointment + backport subject R5

### DIFF
--- a/input/fsh/Examples/FRCoreAppointmentExample.fsh
+++ b/input/fsh/Examples/FRCoreAppointmentExample.fsh
@@ -2,8 +2,6 @@ Instance: FRCoreAppointmentExample
 InstanceOf: fr-core-appointment
 Usage: #example
 Description: "Exemple de ressource Appointment pour décrire un état de rendez-vous médical"
-* extension.url = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-appointment-operator"
-* extension.valueReference = Reference(FRCorePatientINSExample)
 * identifier.system = "http://appointment-identifier-system.org"
 * identifier.value = "123"
 * status = #proposed
@@ -22,4 +20,7 @@ Description: "Exemple de ressource Appointment pour décrire un état de rendez-
 * participant[+].actor = Reference(FRCorePractitionerExample)
 * participant[=].required = #required
 * participant[=].status = #needs-action
+* participant[+].type = http://terminology.hl7.org/CodeSystem/v3-ParticipationType#ENT
+* participant[=].actor = Reference(FRCorePractitionerExample)
+* participant[=].status = #accepted
 * requestedPeriod.start = "2019-01-04T09:15:00Z"

--- a/input/fsh/Examples/FRCoreAppointmentExample.fsh
+++ b/input/fsh/Examples/FRCoreAppointmentExample.fsh
@@ -2,6 +2,7 @@ Instance: FRCoreAppointmentExample
 InstanceOf: fr-core-appointment
 Usage: #example
 Description: "Exemple de ressource Appointment pour décrire un état de rendez-vous médical"
+* extension[subject].valueReference = Reference(FRCorePatientINSExample)
 * identifier.system = "http://appointment-identifier-system.org"
 * identifier.value = "123"
 * status = #proposed

--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -69,6 +69,7 @@ Alias: $workflow-supportingInfo = http://hl7.org/fhir/StructureDefinition/workfl
 Alias: $ServiceType = http://terminology.hl7.org/CodeSystem/service-type
 Alias: $patient-birthPlace = http://hl7.org/fhir/StructureDefinition/patient-birthPlace
 Alias: $organization-description-r5 = http://hl7.org/fhir/5.0/StructureDefinition/extension-Organization.description
+Alias: $appointment-subject-r5 = http://hl7.org/fhir/5.0/StructureDefinition/extension-Appointment.subject
 
 
 // ###############

--- a/input/fsh/extensions/FRCoreAppointmentOperatorExtension.fsh
+++ b/input/fsh/extensions/FRCoreAppointmentOperatorExtension.fsh
@@ -4,4 +4,5 @@ Title: "FR Core Appointment Operator Extension"
 Description: "Cette extension ajoute l'élément appointmentOperator à la ressource Appointment (opérateur de création/modification/annulation du RDV). \r\nThis extension adds the element appointmentOperator to the Appointment resource (operator of creation/update/cancel of the appointment"
 * ^context.type = #element
 * ^context.expression = "Appointment"
+* value[x] only Reference
 * valueReference only Reference(FRCoreOrganizationProfile or FRCorePractitionerProfile or FRCorePatientProfile or RelatedPerson)

--- a/input/fsh/extensions/FRCoreAppointmentOperatorExtension.fsh
+++ b/input/fsh/extensions/FRCoreAppointmentOperatorExtension.fsh
@@ -1,8 +1,0 @@
-Extension: FRCoreAppointmentOperatorExtension
-Id: fr-core-appointment-operator
-Title: "FR Core Appointment Operator Extension"
-Description: "Cette extension ajoute l'élément appointmentOperator à la ressource Appointment (opérateur de création/modification/annulation du RDV). \r\nThis extension adds the element appointmentOperator to the Appointment resource (operator of creation/update/cancel of the appointment"
-* ^context.type = #element
-* ^context.expression = "Appointment"
-* value[x] only Reference
-* valueReference only Reference(FRCoreOrganizationProfile or FRCorePractitionerProfile or FRCorePatientProfile or RelatedPerson)

--- a/input/fsh/profiles/FRCoreAppointmentProfile.fsh
+++ b/input/fsh/profiles/FRCoreAppointmentProfile.fsh
@@ -2,8 +2,8 @@ Profile: FRCoreAppointmentProfile
 Parent: Appointment
 Id: fr-core-appointment
 Title: "FR Core Appointment Profile"
-Description: "Profile of the Appointment resource for France. This profile adds the operator who created/updated/canceled the appointment. It also allows to possibly reference an appointment canceled and a document associated with the appointment.\r\n
-Profil de la ressource Appointment pour la France. Ce profil ajoute l'opérateur qui a créé/modifié/annulé le RDV. Il permet également de référencer éventuellement un RDV annulé et/ou un document lié au RDV."
+Description: "Profile of the Appointment resource for France. It allows to possibly reference an appointment canceled and a document associated with the appointment.\r\n
+Profil de la ressource Appointment pour la France. Il permet de référencer éventuellement un RDV annulé et/ou un document lié au RDV."
 
 * meta.profile ^slicing.discriminator.type = #value
 * meta.profile ^slicing.discriminator.path = "$this"
@@ -15,8 +15,10 @@ Profil de la ressource Appointment pour la France. Ce profil ajoute l'opérateur
 * extension ^slicing.discriminator.type = #value
 * extension ^slicing.discriminator.path = "url"
 * extension ^slicing.rules = #open
+* extension contains $appointment-subject-r5 named subject 0..1
 
-* extension contains FRCoreAppointmentOperatorExtension named appointmentOperator 0..1
+* extension[subject] ^short = "Sujet du rendez-vous (patient ou groupe) — backport R5 Appointment.subject"
+* extension[subject].value[x] only Reference(FRCorePatientProfile or Group)
 
 * specialty from FRCoreValueSetPractitionerSpecialty (required)
 * specialty ^binding.extension.url = "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName"
@@ -24,4 +26,15 @@ Profil de la ressource Appointment pour la France. Ce profil ajoute l'opérateur
 
 * slot only Reference(FRCoreSlotProfile)
 
+* participant ^slicing.discriminator.type = #value
+* participant ^slicing.discriminator.path = "type"
+* participant ^slicing.rules = #open
+* participant contains appointmentOperator 0..*
+
+* participant[appointmentOperator] ^short = "Opérateur ayant saisi ou modifié le rendez-vous"
+* participant[appointmentOperator].type 1..*
+* participant[appointmentOperator].type = http://terminology.hl7.org/CodeSystem/v3-ParticipationType#ENT
+* participant[appointmentOperator].actor only Reference(FRCoreOrganizationProfile or FRCorePractitionerProfile or FRCorePatientProfile or RelatedPerson)
+
+* participant.type from FRCoreValueSetAppointmentParticipantType (extensible)
 * participant.actor only Reference(Device or PractitionerRole or FRCoreRelatedPersonProfile or FRCoreHealthcareServiceProfile or FRCorePractitionerProfile or FRCorePatientProfile or FRCoreLocationProfile)

--- a/input/fsh/profiles/FRCoreAppointmentProfile.fsh
+++ b/input/fsh/profiles/FRCoreAppointmentProfile.fsh
@@ -31,7 +31,7 @@ Profil de la ressource Appointment pour la France. Il permet de référencer év
 * participant ^slicing.rules = #open
 * participant contains appointmentOperator 0..*
 
-* participant[appointmentOperator] ^short = "Opérateur ayant saisi ou modifié le rendez-vous"
+* participant[appointmentOperator] ^short = "Opérateur ayant saisi, modifié ou annulé le rendez-vous"
 * participant[appointmentOperator].type 1..*
 * participant[appointmentOperator].type = http://terminology.hl7.org/CodeSystem/v3-ParticipationType#ENT
 * participant[appointmentOperator].actor only Reference(FRCoreOrganizationProfile or FRCorePractitionerProfile or FRCorePatientProfile or RelatedPerson)

--- a/input/fsh/valuesets/FRCoreValueSetAppointmentParticipantType.fsh
+++ b/input/fsh/valuesets/FRCoreValueSetAppointmentParticipantType.fsh
@@ -1,0 +1,11 @@
+ValueSet: FRCoreValueSetAppointmentParticipantType
+Id: fr-core-vs-appointment-participant-type
+Title: "FR Core ValueSet Appointment Participant Type"
+Description: "Codes décrivant le rôle d'un participant dans un rendez-vous médical. Étend le ValueSet HL7 encounter-participant-type avec le code ENT (data enterer) pour représenter l'opérateur ayant saisi ou modifié le rendez-vous."
+* insert SetValueset
+
+* include codes from valueset http://hl7.org/fhir/ValueSet/encounter-participant-type
+* http://terminology.hl7.org/CodeSystem/v3-ParticipationType#ENT "data entry person"
+* http://terminology.hl7.org/CodeSystem/v3-ParticipationType#SBJ "subject"
+
+* ^experimental = false

--- a/input/pagecontent/change_notes.md
+++ b/input/pagecontent/change_notes.md
@@ -1,3 +1,39 @@
+### Release 2.3.0 de l'Implementation Guide FRCore
+
+* **[BREAKING CHANGE]** Appointment : suppression de l'extension `FRCoreAppointmentOperatorExtension` (`fr-core-appointment-operator`) et modélisation de l'opérateur via `Appointment.participant` [#297](https://github.com/Interop-Sante/hl7.fhir.fr.core/issues/297)
+
+L'extension `appointmentOperator` permettait de référencer la personne ayant créé/modifié/annulé un rendez-vous. Cette modélisation via une extension propriétaire était redondante avec `Appointment.participant`, qui supporte nativement des participants non présents lors de l'acte (ex. : `referrer`). Elle est remplacée par une slice `appointmentOperator` sur `participant`, utilisant le code standard `ENT` (_data entry person_) du CodeSystem `v3-ParticipationType`.
+
+**Avant (version 2.2.0)**
+
+```json
+{
+  "resourceType": "Appointment",
+  "extension": [{
+    "url": "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-appointment-operator",
+    "valueReference": { "reference": "Practitioner/123" }
+  }]
+}
+```
+
+**Après (version 2.3.0)**
+
+```json
+{
+  "resourceType": "Appointment",
+  "participant": [{
+    "type": [{ "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType", "code": "ENT" }] }],
+    "actor": { "reference": "Practitioner/123" },
+    "status": "accepted"
+  }]
+}
+```
+
+> **Impact pour les implémenteurs** : les ressources utilisant l'extension `fr-core-appointment-operator` doivent migrer vers `participant` avec `type = ENT`. Les IGs dépendant de FRCore qui utilisent cette extension (notamment GAP) devront être mis à jour.
+
+* Appointment : ajout du ValueSet `FRCoreValueSetAppointmentParticipantType` pour le binding de `participant.type`, étendant `encounter-participant-type` avec les codes `ENT` (_data entry person_) et `SBJ` (_subject_) du CodeSystem `v3-ParticipationType` [#297](https://github.com/Interop-Sante/hl7.fhir.fr.core/issues/297)
+* Appointment : ajout de l'extension cross-version R5 `Appointment.subject` (`http://hl7.org/fhir/5.0/StructureDefinition/extension-Appointment.subject`) pour identifier explicitement le patient sujet du rendez-vous, en anticipation de FHIR R5 qui introduit cet élément nativement [#5](https://github.com/Interop-Sante/hl7.fhir.fr.core/issues/5)
+
 ### [Release 2.2.0](https://hl7.fr/ig/fhir/core/2.2.0) de l'Implementation Guide FRCore
 [Modifications apportées dans la release 2.2.0](https://github.com/Interop-Sante/hl7.fhir.fr.core/milestone/10?closed=1) :
 


### PR DESCRIPTION
## Description des changements | Description of changes made

* **[BREAKING CHANGE]** Suppression de `FRCoreAppointmentOperatorExtension` (`fr-core-appointment-operator`) — l'opérateur est désormais modélisé via `Appointment.participant` avec `type = ENT` (_data entry person_, `v3-ParticipationType`), approche plus idiomatique FHIR (cf. [#297](https://github.com/Interop-Sante/hl7.fhir.fr.core/issues/297))
* Création du ValueSet `FRCoreValueSetAppointmentParticipantType` étendant `encounter-participant-type` avec les codes `ENT` et `SBJ` (_subject_) du CodeSystem `v3-ParticipationType`
* Ajout de la slice `appointmentOperator` sur `Appointment.participant` (type contraint à `ENT`, actor limité à `Practitioner | Organization | Patient | RelatedPerson`)
* Ajout de l'extension cross-version R5 `Appointment.subject` (`http://hl7.org/fhir/5.0/StructureDefinition/extension-Appointment.subject`) pour identifier explicitement le patient sujet du RDV, en anticipation de FHIR R5 (cf. [#5](https://github.com/Interop-Sante/hl7.fhir.fr.core/issues/5))
* Mise à jour de l'exemple `FRCoreAppointmentExample` pour illustrer la nouvelle modélisation
* Mise à jour du change log (entrée 2.3.0)

> ⚠️ **Impact sur les IGs dépendants** : les implémenteurs utilisant `fr-core-appointment-operator` doivent migrer vers `participant[type=ENT]`. Le profil GAP (`GAP-FrAppointment`) est notamment concerné.


## TODO

Problème à résoudre : l'extension pouvait pointer sur Organization alors que Appointment.participant.actor ne le permet pas.

## Preview

https://interop-sante.github.io/hl7.fhir.fr.core/nriss-patch-2/ig