### PR TITLE
Page à propos : ajout cycle de vie CI-SIS et correction statut publication-request

### DIFF
--- a/input/pagecontent/a_propos.md
+++ b/input/pagecontent/a_propos.md
@@ -2,7 +2,7 @@ En tant qu'affilié français d'HL7 International, InteropSanté a la responsabi
 
 ### Cycle de vie
 
-FRCore suit le [cycle de vie des guides d'implémentation FHIR](https://interop.esante.gouv.fr/ig/doctrine/cycle-de-vie.html) défini dans la doctrine du CI-SIS.
+FRCore suit le [cycle de vie des guides d'implémentation FHIR](https://interop.esante.gouv.fr/ig/doctrine/cycle-de-vie.html) défini dans la doctrine du CI-SIS. La correspondance entre les statuts du cycle de vie et le paramétrage des fichiers de configuration est documentée dans les [bonnes pratiques de release d'un IG FHIR](https://ansforge.github.io/IG-documentation/nr-clarify-release-fields/ig/mod_bonnes_pratiques.html#release-dun-ig-fhir).
 
 Les évolutions à venir — héritage des profils européens, synchronisation avec l'IG Document Core, et migration vers FHIR R6 — impliquent des changements structurels qui ne permettent pas, à ce stade, un passage au statut `final-text`.
 

--- a/input/pagecontent/a_propos.md
+++ b/input/pagecontent/a_propos.md
@@ -1,5 +1,11 @@
 En tant qu'affilié français d'HL7 International, InteropSanté a la responsabilité de créer les profils FHIR génériques à usage français.
 
+### Cycle de vie
+
+FRCore suit le [cycle de vie des guides d'implémentation FHIR](https://interop.esante.gouv.fr/ig/doctrine/cycle-de-vie.html) défini dans la doctrine du CI-SIS.
+
+Les évolutions à venir — héritage des profils européens, synchronisation avec l'IG Document Core, et migration vers FHIR R6 — impliquent des changements structurels qui ne permettent pas, à ce stade, un passage au statut `final-text`.
+
 ### Comment contribuer ?
 
 La qualité de ce guide d'implémentation s'améliore continuellement grâce aux précieuses contributions de la communauté. Pour rejoindre cette communauté, il suffit de rejoindre le [Google Group FHIR France](https://groups.google.com/g/groupes-fhir-france) ou bien le [slack FHIR France](https://join.slack.com/t/fhir-france/shared_invite/zt-2pv7q7ern-VIrh8Q9r4hrOJPQk3j_ouA), et d'adhérer à [InteropSanté](https://www.interopsante.org/).

--- a/input/pagecontent/bonnes_pratiques.md
+++ b/input/pagecontent/bonnes_pratiques.md
@@ -11,6 +11,20 @@ En FHIR, il y a plusieurs types d'identifiants :
 
 Il est conseillé de favoriser l'usage des identifiants métiers pour faciliter l'identification de la ressource en dehors du serveur.
 
+#### Indiquer la version du profil dans meta.profile
+
+Il n'est pas toujours évident de déterminer sur quelle version d'un profil se base une instance de ressource FHIR. Il est donc conseillé aux producteurs de ressources d'indiquer explicitement la version du profil dans `meta.profile`, en utilisant la [syntaxe `url|version` définie par la spécification FHIR](https://hl7.org/fhir/references.html#canonical) :
+
+```json
+"meta": {
+  "profile": [
+    "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-patient|2.2.0"
+  ]
+}
+```
+
+Cette pratique facilite la validation, le débogage et l'interopérabilité entre systèmes, en particulier lorsque plusieurs versions d'un même profil coexistent.
+
 #### Les syntaxes retenues
 
 Parmi les trois syntaxes disponibles pour implémenter FHIR, les syntaxes retenues sont les syntaxes XML et JSON.

--- a/publication-request.json
+++ b/publication-request.json
@@ -3,7 +3,7 @@
     "version" : "2.2.0",
     "path" : "https://hl7.fr/ig/fhir/core/2.2.0",
     "mode" : "milestone",
-    "status" : "trial-use",
+    "status" : "trial-implementation",
     "sequence" : "final-text",
     "desc" : "Guide d'implémentation Fr Core 2.2.0 - profils génériques à usage national",
     "changes": "change_notes.html"

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -16,7 +16,7 @@ status: active
 version: 2.2.0
 fhirVersion: 4.0.1
 copyrightYear: 2023+
-releaseLabel: trial-use
+releaseLabel: ci-build
 jurisdiction: urn:iso:std:iso:3166#FR "France (la)"
 
 dependencies:


### PR DESCRIPTION
## Description des changements

Suite à la discussion du groupe de travail du 11 juin 2026 :

* `input/pagecontent/a_propos.md` : ajout d'une section "Cycle de vie" mentionnant que FRCore suit le cycle de vie défini dans la doctrine CI-SIS, avec une note expliquant que les évolutions à venir (héritage européen, IG Document Core, FHIR R6) ne permettent pas un passage au statut `final-text`
* `publication-request.json` : correction du statut de `trial-use` vers `trial-implementation`
* `input/pagecontent/bonnes_pratiques.md` : ajout d'une bonne pratique recommandant d'indiquer la version du profil dans `meta.profile` avec la syntaxe `url|version`
* `sushi-config.yaml` : passage du `releaseLabel` à `ci-build`

## Preview

https://interop-sante.github.io/hl7.fhir.fr.core/nr-update-cycle/ig