### PR TITLE
fix(a_propos): encapsulation de la note sur les évolutions à venir

### DIFF
--- a/input/pagecontent/a_propos.md
+++ b/input/pagecontent/a_propos.md
@@ -4,7 +4,11 @@ En tant qu'affilié français d'HL7 International, InteropSanté a la responsabi
 
 FRCore suit le [cycle de vie des guides d'implémentation FHIR](https://interop.esante.gouv.fr/ig/doctrine/cycle-de-vie.html) défini dans la doctrine du CI-SIS. La correspondance entre les statuts du cycle de vie et le paramétrage des fichiers de configuration est documentée dans les [bonnes pratiques de release d'un IG FHIR](https://ansforge.github.io/IG-documentation/nr-clarify-release-fields/ig/mod_bonnes_pratiques.html#release-dun-ig-fhir).
 
-Les évolutions à venir — héritage des profils européens, synchronisation avec l'IG Document Core, et migration vers FHIR R6 — impliquent des changements structurels qui ne permettent pas, à ce stade, un passage au statut `final-text`.
+<blockquote class="stu-note">
+<p>
+Les évolutions à venir (héritage des profils européens, synchronisation avec l'IG Document Core, migration vers FHIR R6) impliquent des changements structurels qui ne permettent pas, à ce stade, un passage au statut <code>final-text</code>.
+</p>
+</blockquote>
 
 ### Comment contribuer ?
 


### PR DESCRIPTION
## Description des changements

* Encapsulation de la phrase sur les évolutions à venir (`final-text`) dans un bloc `<blockquote class="stu-note">` pour attirer l'attention du lecteur
* Remplacement des tirets médians (—) par des parenthèses

## Type de changement

- [ ] Nouveau contenu (profil, extension, page, exemple)
- [x] Correction (erreur dans un profil, une page, une dépendance)
- [ ] Refactoring (pas de changement fonctionnel)
- [ ] Release

## Checklist

- [x] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement
- [ ] `change-log.md` mis à jour
- [x] La branche est à jour avec `main`

## Preview

https://interop-sante.github.io/hl7.fhir.fr.core/nr-note-a-propos-evolutions/ig/a_propos.html

---

Fait suite à la review de @sdemeyANS sur la PR #308.