### PR TITLE
Fix #328: binding required sur FRCoreValueSetINSEECode + codes TRE_R20-Pays

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 ## Checklist
 
 - [ ] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement | `releaseLabel` is `ci-build` for a version in development
-- [ ] `input/pagecontent/change_notes.md` mis à jour (si Release) | `input/pagecontent/change_notes.md` updated (if Release)
+- [ ] `input/pagecontent/change_notes.md` mis à jour | `input/pagecontent/change_notes.md` updated
 - [ ] La branche est à jour avec `main` | The branch is up to date with `main`
 
 ## Preview

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,7 @@
 ## Checklist
 
 - [ ] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement | `releaseLabel` is `ci-build` for a version in development
+- [ ] `input/pagecontent/change_notes.md` mis à jour (si Release) | `input/pagecontent/change_notes.md` updated (if Release)
 - [ ] La branche est à jour avec `main` | The branch is up to date with `main`
 
 ## Preview

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,18 @@
 * [changement 2]
 * ...
 
+## Type de changement | Type of change
+
+- [ ] Nouveau contenu (profil, extension, page, exemple) | New content (profile, extension, page, example)
+- [ ] Correction (erreur dans un profil, une page, une dépendance) | Fix (error in a profile, a page, a dependency)
+- [ ] Refactoring (pas de changement fonctionnel) | Refactoring (no functional change)
+- [ ] Release
+
+## Checklist
+
+- [ ] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement | `releaseLabel` is `ci-build` for a version in development
+- [ ] La branche est à jour avec `main` | The branch is up to date with `main`
+
 ## Preview
 
 https://interop-sante.github.io/hl7.fhir.fr.core/[ajouter_nom_de_la_branche]/ig

--- a/input/fsh/extensions/FRCoreAddressInseeCodeExtension.fsh
+++ b/input/fsh/extensions/FRCoreAddressInseeCodeExtension.fsh
@@ -6,4 +6,4 @@ Description: """Extension d'ajout du code insee (5 chiffres) à l'adresse postal
 * ^context.type = #element
 * ^context.expression = "Address"
 * value[x] only Coding
-* value[x] from FRCoreValueSetINSEECode (extensible) //R13
+* value[x] from FRCoreValueSetINSEECode (required)

--- a/input/fsh/valuesets/FRCoreValueSetINSEECode.fsh
+++ b/input/fsh/valuesets/FRCoreValueSetINSEECode.fsh
@@ -5,6 +5,7 @@ Description: "the French Address Insee Codes"
 * insert SetValueset
 
 * include codes from system https://mos.esante.gouv.fr/NOS/TRE_R13-CommuneOM/FHIR/TRE-R13-CommuneOM
+* include codes from system https://mos.esante.gouv.fr/NOS/TRE_R20-Pays/FHIR/TRE-R20-Pays
 
 // SVS profile
 * ^experimental = false


### PR DESCRIPTION
## Description des changements | Description of changes made

* Ajout des codes du CodeSystem `TRE_R20-Pays` dans `FRCoreValueSetINSEECode`, en complément de `TRE_R13-CommuneOM`, afin de couvrir explicitement le cas d'une localisation à l'étranger prévu par `FRCoreAddressInseeCodeExtension`
* Rétablissement du binding `required` (au lieu de `extensible`) sur `FRCoreAddressInseeCodeExtension.value[x]`, le ValueSet couvrant désormais l'ensemble des référentiels attendus
* Complément du template de PR avec les sections "Type de changement" et "Checklist" (repris et adaptés du template ANS)

Résout #328

## Type de changement | Type of change

- [ ] Nouveau contenu (profil, extension, page, exemple) | New content (profile, extension, page, example)
- [x] Correction (erreur dans un profil, une page, une dépendance) | Fix (error in a profile, a page, a dependency)
- [ ] Refactoring (pas de changement fonctionnel) | Refactoring (no functional change)
- [ ] Release

## Checklist

- [x] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement | `releaseLabel` is `ci-build` for a version in development
- [ ] `input/pagecontent/change_notes.md` mis à jour | `input/pagecontent/change_notes.md` updated
- [x] La branche est à jour avec `main` | The branch is up to date with `main`

## Preview

https://interop-sante.github.io/hl7.fhir.fr.core/fix/328-insee-code-valueset/ig

🤖 Generated with [Claude Code](https://claude.com/claude-code)