### PR TITLE
Fix: titre CodeSystem dupliqué (Mode Validation Identite / Method Collection)

### DIFF
--- a/input/fsh/codesystems/FRCoreCodeSystemIdentityMethodCollection.fsh
+++ b/input/fsh/codesystems/FRCoreCodeSystemIdentityMethodCollection.fsh
@@ -1,6 +1,6 @@
 CodeSystem: FRCoreCodeSystemMethodCollection
 Id: fr-core-cs-method-collection
-Title: "FR Core CodeSystem Mode Validation Identite"
+Title: "FR Core CodeSystem Method Collection"
 Description: "Méthode de collection de l'identité"
 * insert SetCodesystem
 


### PR DESCRIPTION
## Description des changements | Description of changes made

* Correction du `Title` du CodeSystem `fr-core-cs-method-collection` qui était un copier-coller du titre de `fr-core-cs-mode-validation-identity`, provoquant l'erreur du publisher `There are multiple resources with the same title [...]` (doublon dans la table des matières) | Fixed the `Title` of CodeSystem `fr-core-cs-method-collection`, which was a copy-paste of the title of `fr-core-cs-mode-validation-identity`, causing the publisher error `There are multiple resources with the same title [...]` (duplicate table-of-contents entry)

## Type de changement | Type of change

- [ ] Nouveau contenu (profil, extension, page, exemple) | New content (profile, extension, page, example)
- [x] Correction (erreur dans un profil, une page, une dépendance) | Fix (error in a profile, a page, a dependency)
- [ ] Refactoring (pas de changement fonctionnel) | Refactoring (no functional change)
- [ ] Release

## Checklist

- [x] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement | `releaseLabel` is `ci-build` for a version in development
- [ ] `input/pagecontent/change_notes.md` mis à jour | `input/pagecontent/change_notes.md` updated
- [x] La branche est à jour avec `main` | The branch is up to date with `main`

## Preview

https://interop-sante.github.io/hl7.fhir.fr.core/nr-fix-cs-title-duplicate/ig